### PR TITLE
refactor(merge-strategies): extract strategies into core/merge-strategies and add LWW strategy

### DIFF
--- a/packages/react-p2p/src/core/merge-strategies/index.ts
+++ b/packages/react-p2p/src/core/merge-strategies/index.ts
@@ -1,0 +1,3 @@
+export { createLamportStrategy, type LamportMeta } from './lamport';
+export { createLastWriteWinsStrategy, type LastWriteWinsMeta } from './lastWriteWins';
+export type { MergeMeta, MergeStrategy } from './types';

--- a/packages/react-p2p/src/core/merge-strategies/lamport.ts
+++ b/packages/react-p2p/src/core/merge-strategies/lamport.ts
@@ -1,0 +1,60 @@
+import type { JSONSerializable } from '../../context/Room';
+import type { MergeStrategy } from './types';
+
+/**
+ * Metadata carried by the Lamport clock strategy.
+ * `clock` is a monotonically increasing logical counter; `tiebreaker` is the
+ * writing peer's ID, used to deterministically resolve equal-clock conflicts.
+ */
+export type LamportMeta = { clock: number; tiebreaker: string };
+
+/**
+ * Creates a Lamport logical-clock merge strategy.
+ *
+ * Unlike wall-clock timestamps, Lamport clocks do not rely on peers having
+ * synchronised system clocks. The clock advances monotonically: it increments
+ * on every local write and is fast-forwarded to `max(local, incoming)` on
+ * every receive, so causal ordering is preserved across all peers.
+ *
+ * Concurrent writes (same clock value) are broken deterministically by
+ * comparing the writing peer's ID as a string, so every peer reaches the same
+ * result independently.
+ *
+ * @param getPeerId - A function that returns the local peer's ID at call time.
+ *   Pass a ref-backed getter so the strategy stays stable even before the
+ *   signalling handshake completes.
+ */
+export function createLamportStrategy(
+  getPeerId: () => string
+): MergeStrategy<JSONSerializable, LamportMeta> {
+  let localClock = 0;
+
+  return {
+    initialMeta: { clock: 0, tiebreaker: getPeerId() },
+
+    createMeta(): LamportMeta {
+      return { clock: ++localClock, tiebreaker: getPeerId() };
+    },
+
+    merge(
+      _currentState,
+      currentMeta,
+      incomingState,
+      incomingMeta,
+      senderId
+    ): { state: JSONSerializable | null; meta: LamportMeta } | null {
+      localClock = Math.max(localClock, incomingMeta.clock);
+
+      const clockWins = incomingMeta.clock > currentMeta.clock;
+      const incomingTiebreaker = incomingMeta.tiebreaker || senderId;
+      const currentTiebreaker = currentMeta.tiebreaker || getPeerId();
+
+      const tiebreakWins =
+        incomingMeta.clock === currentMeta.clock && incomingTiebreaker > currentTiebreaker;
+
+      return clockWins || tiebreakWins
+        ? { state: incomingState, meta: { ...incomingMeta, tiebreaker: incomingTiebreaker } }
+        : null;
+    },
+  };
+}

--- a/packages/react-p2p/src/core/merge-strategies/lastWriteWins.ts
+++ b/packages/react-p2p/src/core/merge-strategies/lastWriteWins.ts
@@ -1,0 +1,58 @@
+import type { JSONSerializable } from '../../context/Room';
+import type { MergeStrategy } from './types';
+
+/**
+ * Metadata carried by the Last Write Wins strategy.
+ * `timestamp` is a wall-clock time in milliseconds; `tiebreaker` is the
+ * writing peer's ID, used to deterministically resolve same-millisecond conflicts.
+ */
+export type LastWriteWinsMeta = { timestamp: number; tiebreaker: string };
+
+/**
+ * Creates a Last Write Wins merge strategy.
+ *
+ * Accepts the incoming state whenever its wall-clock timestamp is strictly
+ * greater than the current one. Ties (same millisecond) are broken
+ * deterministically by comparing peer ID strings, so every peer converges to
+ * the same result independently without coordination.
+ *
+ * Note: this strategy relies on peers having reasonably synchronised system
+ * clocks. It is appropriate for use cases where approximate recency is
+ * sufficient (e.g. presence indicators, cursor positions, UI state), but
+ * should not be used where causal ordering must be guaranteed — prefer
+ * `createLamportStrategy` in that case.
+ *
+ * @param getPeerId - A function that returns the local peer's ID at call time.
+ *   Pass a ref-backed getter so the strategy stays stable even before the
+ *   signalling handshake completes.
+ */
+export function createLastWriteWinsStrategy(
+  getPeerId: () => string
+): MergeStrategy<JSONSerializable, LastWriteWinsMeta> {
+  return {
+    initialMeta: { timestamp: 0, tiebreaker: getPeerId() },
+
+    createMeta(): LastWriteWinsMeta {
+      return { timestamp: Date.now(), tiebreaker: getPeerId() };
+    },
+
+    merge(
+      _currentState,
+      currentMeta,
+      incomingState,
+      incomingMeta,
+      senderId
+    ): { state: JSONSerializable | null; meta: LastWriteWinsMeta } | null {
+      const incomingTiebreaker = incomingMeta.tiebreaker || senderId;
+      const currentTiebreaker = currentMeta.tiebreaker || getPeerId();
+
+      const timestampWins = incomingMeta.timestamp > currentMeta.timestamp;
+      const tiebreakWins =
+        incomingMeta.timestamp === currentMeta.timestamp && incomingTiebreaker > currentTiebreaker;
+
+      return timestampWins || tiebreakWins
+        ? { state: incomingState, meta: { ...incomingMeta, tiebreaker: incomingTiebreaker } }
+        : null;
+    },
+  };
+}

--- a/packages/react-p2p/src/core/merge-strategies/types.ts
+++ b/packages/react-p2p/src/core/merge-strategies/types.ts
@@ -1,0 +1,26 @@
+import type { JSONSerializable } from '../../context/Room';
+
+export type MergeMeta = Record<string, JSONSerializable>;
+
+export interface MergeStrategy<
+  TState extends JSONSerializable = JSONSerializable,
+  TMeta extends MergeMeta = MergeMeta,
+> {
+  /** Initial metadata before any sync or update. */
+  initialMeta: TMeta;
+
+  /** Produce meta when this peer sets state (e.g. timestamp, version). */
+  createMeta(): TMeta;
+
+  /**
+   * Decide how to merge incoming state with current.
+   * Return new { state, meta } to apply, or null to keep current.
+   */
+  merge(
+    currentState: TState | null,
+    currentMeta: TMeta,
+    incomingState: TState | null,
+    incomingMeta: TMeta,
+    senderId: string
+  ): { state: TState | null; meta: TMeta } | null;
+}

--- a/packages/react-p2p/src/hooks/useSharedState.ts
+++ b/packages/react-p2p/src/hooks/useSharedState.ts
@@ -1,31 +1,12 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useRoom } from '..';
 import type { JSONSerializable } from '../context/Room';
-
-export type MergeMeta = Record<string, JSONSerializable>;
-
-export interface MergeStrategy<
-  TState extends JSONSerializable = JSONSerializable,
-  TMeta extends MergeMeta = MergeMeta,
-> {
-  /** Initial metadata before any sync or update. */
-  initialMeta: TMeta;
-
-  /** Produce meta when this peer sets state (e.g. timestamp, version). */
-  createMeta(): TMeta;
-
-  /**
-   * Decide how to merge incoming state with current.
-   * Return new { state, meta } to apply, or null to keep current.
-   */
-  merge(
-    currentState: TState | null,
-    currentMeta: TMeta,
-    incomingState: TState | null,
-    incomingMeta: TMeta,
-    senderId: string
-  ): { state: TState | null; meta: TMeta } | null;
-}
+import {
+  createLamportStrategy,
+  type LamportMeta,
+  type MergeMeta,
+  type MergeStrategy,
+} from '../core/merge-strategies';
 
 type SharedStatePayload<TState extends JSONSerializable, TMeta extends MergeMeta = MergeMeta> = {
   key: string;
@@ -44,65 +25,6 @@ function isStateRequest(
   return (
     typeof data === 'object' && data !== null && 'type' in data && data.type === 'state-request'
   );
-}
-
-/**
- * Metadata carried by the Lamport clock strategy.
- * `clock` is a monotonically increasing logical counter; `tiebreaker` is the
- * writing peer's ID, used to deterministically resolve equal-clock conflicts.
- */
-export type LamportMeta = { clock: number; tiebreaker: string };
-
-/**
- * Creates a Lamport logical-clock merge strategy.
- *
- * Unlike wall-clock timestamps, Lamport clocks do not rely on peers having
- * synchronised system clocks. The clock advances monotonically: it increments
- * on every local write and is fast-forwarded to `max(local, incoming)` on
- * every receive, so causal ordering is preserved across all peers.
- *
- * Concurrent writes (same clock value) are broken deterministically by
- * comparing the writing peer's ID as a string, so every peer reaches the same
- * result independently.
- *
- * @param getPeerId - A function that returns the local peer's ID at call time.
- *   Pass a ref-backed getter so the strategy stays stable even before the
- *   signalling handshake completes.
- */
-export function createLamportStrategy(
-  getPeerId: () => string
-): MergeStrategy<JSONSerializable, LamportMeta> {
-  let localClock = 0;
-
-  return {
-    initialMeta: { clock: 0, tiebreaker: getPeerId() },
-
-    createMeta(): LamportMeta {
-      return { clock: ++localClock, tiebreaker: getPeerId() };
-    },
-
-    merge(
-      _currentState,
-      currentMeta,
-      incomingState,
-      incomingMeta,
-      senderId
-    ): { state: JSONSerializable | null; meta: LamportMeta } | null {
-      localClock = Math.max(localClock, incomingMeta.clock);
-
-      const clockWins = incomingMeta.clock > currentMeta.clock;
-      const incomingTiebreaker = incomingMeta.tiebreaker || senderId;
-      const currentTiebreaker = currentMeta.tiebreaker || getPeerId();
-
-      const tiebreakWins =
-        incomingMeta.clock === currentMeta.clock &&
-        incomingTiebreaker > currentTiebreaker;
-
-      return clockWins || tiebreakWins
-        ? { state: incomingState, meta: { ...incomingMeta, tiebreaker: incomingTiebreaker } }
-        : null;
-    },
-  };
 }
 
 /**

--- a/packages/react-p2p/src/index.ts
+++ b/packages/react-p2p/src/index.ts
@@ -1,10 +1,12 @@
 // Export Room context and hook
 export { Room, RoomContext, type RoomContextValue } from './context/Room';
-export { useRoom } from './hooks/useRoom';
 export {
   createLamportStrategy,
+  createLastWriteWinsStrategy,
   type LamportMeta,
+  type LastWriteWinsMeta,
   type MergeMeta,
   type MergeStrategy,
-  useSharedState,
-} from './hooks/useSharedState';
+} from './core/merge-strategies';
+export { useRoom } from './hooks/useRoom';
+export { useSharedState } from './hooks/useSharedState';


### PR DESCRIPTION
**Motivation:** Merge strategies were coupled to `useSharedState.ts`, making them hard to discover, extend, or test independently.

**Overview:** Extracts `MergeStrategy`, `LamportMeta`, and `createLamportStrategy` into `core/merge-strategies/`, and adds a new `createLastWriteWinsStrategy` — all publicly re-exported from the package root with no breaking changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Last Write Wins merge strategy for deterministic conflict resolution with timestamp-based tiebreaking.
  * Added Lamport Clock merge strategy for handling concurrent writes using logical clocks and peer identifiers.

* **Refactor**
  * Reorganized merge strategy APIs into a dedicated core module, enabling simpler imports and improved code organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->