### PR TITLE
refactor(types): extract shared types into dedicated types/ module

### DIFF
--- a/packages/react-p2p/src/context/Room.tsx
+++ b/packages/react-p2p/src/context/Room.tsx
@@ -1,28 +1,7 @@
 import { createContext, useCallback, useEffect, useRef, useState } from 'react';
 import { PeerConnection } from '../core/PeerConnection';
 import { SignalingClient } from '../core/SignalingClient';
-
-export type JSONSerializable =
-  | string
-  | number
-  | boolean
-  | null
-  | undefined
-  | JSONSerializable[]
-  | { [key: string]: JSONSerializable };
-
-export type MessageHandler<TData extends JSONSerializable = JSONSerializable> = (
-  message: Message<TData>
-) => void;
-
-export type Message<TData extends JSONSerializable = JSONSerializable> = {
-  /** The peer ID of the sender */
-  senderId: string;
-  /** The data of the message */
-  data: TData;
-  /** The timestamp of when the message was sent */
-  timestamp: number;
-};
+import type { JSONSerializable, Message, MessageHandler } from '../types';
 
 export interface RoomContextValue {
   roomId: string;

--- a/packages/react-p2p/src/context/index.ts
+++ b/packages/react-p2p/src/context/index.ts
@@ -1,0 +1,1 @@
+export { Room, RoomContext, type RoomContextValue } from './Room';

--- a/packages/react-p2p/src/core/merge-strategies/lamport.ts
+++ b/packages/react-p2p/src/core/merge-strategies/lamport.ts
@@ -1,4 +1,4 @@
-import type { JSONSerializable } from '../../context/Room';
+import type { JSONSerializable } from '../../types';
 import type { MergeStrategy } from './types';
 
 /**

--- a/packages/react-p2p/src/core/merge-strategies/lastWriteWins.ts
+++ b/packages/react-p2p/src/core/merge-strategies/lastWriteWins.ts
@@ -1,4 +1,4 @@
-import type { JSONSerializable } from '../../context/Room';
+import type { JSONSerializable } from '../../types';
 import type { MergeStrategy } from './types';
 
 /**

--- a/packages/react-p2p/src/core/merge-strategies/types.ts
+++ b/packages/react-p2p/src/core/merge-strategies/types.ts
@@ -1,4 +1,4 @@
-import type { JSONSerializable } from '../../context/Room';
+import type { JSONSerializable } from '../../types';
 
 export type MergeMeta = Record<string, JSONSerializable>;
 

--- a/packages/react-p2p/src/hooks/index.ts
+++ b/packages/react-p2p/src/hooks/index.ts
@@ -1,0 +1,2 @@
+export { useRoom } from './useRoom';
+export { useSharedState } from './useSharedState';

--- a/packages/react-p2p/src/hooks/useRoom.ts
+++ b/packages/react-p2p/src/hooks/useRoom.ts
@@ -1,5 +1,5 @@
 import { useContext } from 'react';
-import { RoomContext, type RoomContextValue } from '../context/Room';
+import { RoomContext, type RoomContextValue } from '../context';
 
 export function useRoom(): RoomContextValue {
   const context = useContext(RoomContext);

--- a/packages/react-p2p/src/hooks/useSharedState.ts
+++ b/packages/react-p2p/src/hooks/useSharedState.ts
@@ -1,12 +1,12 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { useRoom } from '..';
-import type { JSONSerializable } from '../context/Room';
 import {
   createLamportStrategy,
   type LamportMeta,
   type MergeMeta,
   type MergeStrategy,
 } from '../core/merge-strategies';
+import type { JSONSerializable } from '../types';
+import { useRoom } from './useRoom';
 
 type SharedStatePayload<TState extends JSONSerializable, TMeta extends MergeMeta = MergeMeta> = {
   key: string;

--- a/packages/react-p2p/src/index.ts
+++ b/packages/react-p2p/src/index.ts
@@ -1,5 +1,4 @@
-// Export Room context and hook
-export { Room, RoomContext, type RoomContextValue } from './context/Room';
+export { Room, RoomContext, type RoomContextValue } from './context';
 export {
   createLamportStrategy,
   createLastWriteWinsStrategy,
@@ -8,5 +7,5 @@ export {
   type MergeMeta,
   type MergeStrategy,
 } from './core/merge-strategies';
-export { useRoom } from './hooks/useRoom';
-export { useSharedState } from './hooks/useSharedState';
+export { useRoom, useSharedState } from './hooks';
+export type { JSONSerializable, Message, MessageHandler } from './types';

--- a/packages/react-p2p/src/types/core.ts
+++ b/packages/react-p2p/src/types/core.ts
@@ -1,0 +1,21 @@
+export type JSONSerializable =
+  | string
+  | number
+  | boolean
+  | null
+  | undefined
+  | JSONSerializable[]
+  | { [key: string]: JSONSerializable };
+
+export type Message<TData extends JSONSerializable = JSONSerializable> = {
+  /** The peer ID of the sender */
+  senderId: string;
+  /** The data of the message */
+  data: TData;
+  /** The timestamp of when the message was sent */
+  timestamp: number;
+};
+
+export type MessageHandler<TData extends JSONSerializable = JSONSerializable> = (
+  message: Message<TData>
+) => void;

--- a/packages/react-p2p/src/types/index.ts
+++ b/packages/react-p2p/src/types/index.ts
@@ -1,0 +1,1 @@
+export type { JSONSerializable, Message, MessageHandler } from './core';


### PR DESCRIPTION
**Motivation:** `JSONSerializable`, `Message`, and `MessageHandler` were defined in a React component file (`Room.tsx`), forcing core logic and merge strategies to depend on the context layer.

**Overview:** Moves the shared types into a dedicated `src/types/` module, wires up the previously empty `context/` and `hooks/` barrel files, and routes all public exports through those barrels.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized type definitions into a centralized types module for improved code organization.
  * Consolidated public API exports to streamline the package's public interface.
  * Updated internal module references to reflect the new structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->