### PR TITLE
feat: createSharedStore API

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,11 +78,28 @@ jobs:
       - name: Run integration tests
         run: bun run test:integration
 
+  phop-unit-test:
+    name: phop unit tests
+    runs-on: ubuntu-latest
+    needs: [lint]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version-file: ".bun-version"
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Run phop unit tests
+        run: bun --filter=@peterddod/phop run test
+
   semantic-release:
     name: Release
     runs-on: ubuntu-latest
     if: github.event_name == 'push' && (needs.changes.outputs.phop == 'true' || needs.changes.outputs.server == 'true')
-    needs: [lint, changes, integration-test]
+    needs: [lint, changes, integration-test, phop-unit-test]
     permissions:
       contents: write
       issues: write

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "@semantic-release/github": "^12.0.6",
     "@semantic-release/release-notes-generator": "^14.1.0",
     "react-refresh": "^0.18.0",
-    "semantic-release": "^24.0.0"
+    "semantic-release": "^24.0.0",
+    "zustand": "^5.0.12"
   }
 }

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "@semantic-release/github": "^12.0.6",
     "@semantic-release/release-notes-generator": "^14.1.0",
     "react-refresh": "^0.18.0",
-    "semantic-release": "^24.0.0",
-    "zustand": "^5.0.12"
+    "semantic-release": "^24.0.0"
   }
 }

--- a/packages/example/src/App.tsx
+++ b/packages/example/src/App.tsx
@@ -1,6 +1,12 @@
 import './App.css';
+import { useRef } from 'react';
 
 function App() {
+  // Keep one room ID per top-level page load so both iframes share
+  // each other, but do not collide with other open tabs/sessions.
+  const roomIdRef = useRef(crypto.randomUUID());
+  const roomId = encodeURIComponent(roomIdRef.current);
+
   return (
     <div className="app">
       <div className="header">
@@ -11,12 +17,20 @@ function App() {
       <div className="iframes-container">
         <div className="iframe-wrapper">
           <h3>Peer 1</h3>
-          <iframe src="/peer.html?peer=1" title="Peer 1" className="peer-iframe" />
+          <iframe
+            src={`/peer.html?peer=1&roomId=${roomId}`}
+            title="Peer 1"
+            className="peer-iframe"
+          />
         </div>
 
         <div className="iframe-wrapper">
           <h3>Peer 2</h3>
-          <iframe src="/peer.html?peer=2" title="Peer 2" className="peer-iframe" />
+          <iframe
+            src={`/peer.html?peer=2&roomId=${roomId}`}
+            title="Peer 2"
+            className="peer-iframe"
+          />
         </div>
       </div>
 

--- a/packages/example/src/Peer.css
+++ b/packages/example/src/Peer.css
@@ -93,14 +93,21 @@
   word-break: break-all;
 }
 
-.counter-container {
+.demos-container {
   flex: 1;
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  gap: 24px;
-  padding: 40px 20px;
+  gap: 32px;
+  padding: 28px 20px;
+}
+
+.counter-container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 16px;
 }
 
 .counter-label {
@@ -247,4 +254,50 @@
   background: #cbd5e1;
   cursor: not-allowed;
   box-shadow: none;
+}
+
+.store-container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 14px;
+  width: 100%;
+  max-width: 320px;
+}
+
+.store-preview {
+  width: 100%;
+  padding: 14px 18px;
+  border: 2px solid #667eea;
+  border-radius: 10px;
+  min-height: 24px;
+  text-align: center;
+  transition: border-color 0.25s;
+}
+
+.store-preview-text {
+  font-size: 1.15rem;
+  font-weight: 600;
+  transition: color 0.25s;
+}
+
+.store-controls {
+  display: flex;
+  gap: 10px;
+  width: 100%;
+}
+
+.store-input {
+  flex: 1;
+  padding: 10px 14px;
+  border: 2px solid #e2e8f0;
+  border-radius: 8px;
+  font-size: 0.95rem;
+  transition: border-color 0.2s;
+  color: #0f172a;
+}
+
+.store-input:focus {
+  outline: none;
+  border-color: #667eea;
 }

--- a/packages/example/src/PeerComponent.tsx
+++ b/packages/example/src/PeerComponent.tsx
@@ -47,6 +47,7 @@ function SharedLabel({ disabled }: { disabled: boolean }) {
           className="store-input"
           value={label}
           onChange={(e) => setLabel(e.target.value)}
+          aria-label="Shared label"
           placeholder="Shared label"
           disabled={disabled}
           style={{ borderColor: color }}
@@ -63,6 +64,7 @@ function SharedLabel({ disabled }: { disabled: boolean }) {
             height: 40,
             fontSize: '1.1rem',
           }}
+          aria-label="Cycle color"
           title="Cycle color"
         >
           &#9673;

--- a/packages/example/src/PeerComponent.tsx
+++ b/packages/example/src/PeerComponent.tsx
@@ -1,8 +1,76 @@
-import { Room, useRoom, useSharedState } from '@peterddod/phop';
+import { Room, createSharedStore, useRoom, useSharedState } from '@peterddod/phop';
 import { useState } from 'react';
 import './Peer.css';
 
+// ---------------------------------------------------------------------------
+// Zustand-style shared store — defined at module scope, bound inside <Room>
+// ---------------------------------------------------------------------------
+
+interface LabelState {
+  label: string;
+  color: string;
+  setLabel: (label: string) => void;
+  cycleColor: () => void;
+}
+
+const COLORS = ['#667eea', '#22c55e', '#f59e0b', '#ef4444', '#8b5cf6'];
+
+const useLabelStore = createSharedStore<LabelState>('label', (set, get) => ({
+  label: '',
+  color: COLORS[0],
+  setLabel: (label: string) => set({ label }),
+  cycleColor: () => {
+    const idx = COLORS.indexOf(get().color);
+    set({ color: COLORS[(idx + 1) % COLORS.length] });
+  },
+}));
+
 const DEFAULT_SERVER_URL = 'ws://localhost:8080';
+
+function SharedLabel({ disabled }: { disabled: boolean }) {
+  const label = useLabelStore((s) => s.label);
+  const color = useLabelStore((s) => s.color);
+  const setLabel = useLabelStore((s) => s.setLabel);
+  const cycleColor = useLabelStore((s) => s.cycleColor);
+
+  return (
+    <div className="store-container">
+      <p className="counter-label">Shared store (createSharedStore)</p>
+      <div className="store-preview" style={{ borderColor: color }}>
+        <span className="store-preview-text" style={{ color }}>
+          {label || 'Type something...'}
+        </span>
+      </div>
+      <div className="store-controls">
+        <input
+          type="text"
+          className="store-input"
+          value={label}
+          onChange={(e) => setLabel(e.target.value)}
+          placeholder="Shared label"
+          disabled={disabled}
+          style={{ borderColor: color }}
+        />
+        <button
+          type="button"
+          className="counter-button"
+          onClick={cycleColor}
+          disabled={disabled}
+          style={{
+            background: color,
+            boxShadow: `0 2px 8px ${color}55`,
+            width: 40,
+            height: 40,
+            fontSize: '1.1rem',
+          }}
+          title="Cycle color"
+        >
+          &#9673;
+        </button>
+      </div>
+    </div>
+  );
+}
 
 function PeerContent({
   peerName,
@@ -47,27 +115,32 @@ function PeerContent({
         </div>
       </div>
 
-      <div className="counter-container">
-        <p className="counter-label">Shared counter</p>
-        <div className="counter-display">{count ?? 0}</div>
-        <div className="counter-controls">
-          <button
-            type="button"
-            className="counter-button"
-            onClick={() => setCount((count ?? 0) - 1)}
-            disabled={disabled}
-          >
-            −
-          </button>
-          <button
-            type="button"
-            className="counter-button"
-            onClick={() => setCount((count ?? 0) + 1)}
-            disabled={disabled}
-          >
-            +
-          </button>
+      <div className="demos-container">
+        <div className="counter-container">
+          <p className="counter-label">Shared counter (useSharedState)</p>
+          <div className="counter-display">{count ?? 0}</div>
+          <div className="counter-controls">
+            <button
+              type="button"
+              className="counter-button"
+              onClick={() => setCount((count ?? 0) - 1)}
+              disabled={disabled}
+            >
+              −
+            </button>
+            <button
+              type="button"
+              className="counter-button"
+              onClick={() => setCount((count ?? 0) + 1)}
+              disabled={disabled}
+            >
+              +
+            </button>
+          </div>
         </div>
+
+        <SharedLabel disabled={disabled} />
+
         {disabled && (
           <p className="counter-hint">
             {!isConnected ? 'Connecting to room...' : 'Waiting for another peer to join...'}
@@ -87,6 +160,7 @@ function PeerContent({
 export default function PeerComponent() {
   const params = new URLSearchParams(window.location.search);
   const peerName = params.get('peer') || 'Unknown';
+  const roomId = params.get('roomId') || 'demo-room';
 
   const [inputUrl, setInputUrl] = useState(DEFAULT_SERVER_URL);
   const [serverUrl, setServerUrl] = useState<string | null>(null);
@@ -126,7 +200,7 @@ export default function PeerComponent() {
   }
 
   return (
-    <Room signallingServerUrl={serverUrl} roomId="demo-room">
+    <Room signallingServerUrl={serverUrl} roomId={roomId}>
       <PeerContent
         peerName={`Peer ${peerName}`}
         serverUrl={serverUrl}

--- a/packages/example/src/PeerComponent.tsx
+++ b/packages/example/src/PeerComponent.tsx
@@ -1,4 +1,4 @@
-import { Room, createSharedStore, useRoom, useSharedState } from '@peterddod/phop';
+import { createSharedStore, Room, useRoom, useSharedState } from '@peterddod/phop';
 import { useState } from 'react';
 import './Peer.css';
 

--- a/packages/example/src/PeerComponent.tsx
+++ b/packages/example/src/PeerComponent.tsx
@@ -125,7 +125,7 @@ function PeerContent({
             <button
               type="button"
               className="counter-button"
-              onClick={() => setCount((count ?? 0) - 1)}
+              onClick={() => setCount((prev) => (prev ?? 0) - 1)}
               disabled={disabled}
             >
               −
@@ -133,7 +133,7 @@ function PeerContent({
             <button
               type="button"
               className="counter-button"
-              onClick={() => setCount((count ?? 0) + 1)}
+              onClick={() => setCount((prev) => (prev ?? 0) + 1)}
               disabled={disabled}
             >
               +

--- a/packages/example/src/PeerComponent.tsx
+++ b/packages/example/src/PeerComponent.tsx
@@ -1,5 +1,5 @@
 import { createSharedStore, Room, useRoom, useSharedState } from '@peterddod/phop';
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import './Peer.css';
 
 // ---------------------------------------------------------------------------
@@ -160,9 +160,13 @@ function PeerContent({
 }
 
 export default function PeerComponent() {
-  const params = new URLSearchParams(window.location.search);
-  const peerName = params.get('peer') || 'Unknown';
-  const roomId = params.get('roomId') || 'demo-room';
+  const { peerName, roomId } = useMemo(() => {
+    const params = new URLSearchParams(window.location.search);
+    return {
+      peerName: params.get('peer') || 'Unknown',
+      roomId: params.get('roomId') || 'demo-room',
+    };
+  }, []);
 
   const [inputUrl, setInputUrl] = useState(DEFAULT_SERVER_URL);
   const [serverUrl, setServerUrl] = useState<string | null>(null);

--- a/packages/integration-tests/harness/src/exposePhopApi.tsx
+++ b/packages/integration-tests/harness/src/exposePhopApi.tsx
@@ -1,4 +1,5 @@
 import {
+  createSharedStore,
   createConsensusStrategy,
   createLamportStrategy,
   createLastWriteWinsStrategy,
@@ -10,11 +11,33 @@ import {
 import { useCallback, useEffect, useRef, useState } from 'react';
 
 export type SerializedStrategy = 'lamport' | 'lastWriteWins' | 'consensus';
+type SharedSetter = (
+  value: JSONSerializable | null | ((prev: JSONSerializable | null) => JSONSerializable | null)
+) => void;
 
 interface SliceRegistration {
   key: string;
   strategy: SerializedStrategy;
 }
+
+interface LabelState {
+  label: string;
+  color: string;
+  setLabel: (label: string) => void;
+  cycleColor: () => void;
+}
+
+const LABEL_COLORS = ['#667eea', '#22c55e', '#f59e0b', '#ef4444', '#8b5cf6'];
+
+const useLabelStore = createSharedStore<LabelState>('label', (set, get) => ({
+  label: '',
+  color: LABEL_COLORS[0],
+  setLabel: (label: string) => set({ label }),
+  cycleColor: () => {
+    const idx = LABEL_COLORS.indexOf(get().color);
+    set({ color: LABEL_COLORS[(idx + 1) % LABEL_COLORS.length] });
+  },
+}));
 
 interface PhopApi {
   peerId: string;
@@ -30,7 +53,12 @@ interface PhopApi {
   onPeerConnected: (handler: (remotePeerId: string) => void) => () => void;
   registerSharedState: (key: string, strategy?: SerializedStrategy) => Promise<void>;
   setSharedState: (key: string, value: JSONSerializable) => void;
+  incrementSharedState: (key: string, delta?: number) => void;
   getSharedState: (key: string) => JSONSerializable | null;
+  enableLabelProbe: () => Promise<void>;
+  setLabelText: (value: string) => void;
+  typeLabelChar: (char: string) => void;
+  getLabelText: () => string;
   __msgQueue: Array<{ senderId: string; data: JSONSerializable; timestamp: number }>;
   __ack: (key: string) => void;
   __pendingAcks: Map<string, Array<() => void>>;
@@ -61,7 +89,7 @@ interface SharedStateSliceProps {
   stateKey: string;
   strategy: SerializedStrategy;
   stateMapRef: React.RefObject<Map<string, JSONSerializable | null>>;
-  settersRef: React.RefObject<Map<string, (value: JSONSerializable | null) => void>>;
+  settersRef: React.RefObject<Map<string, SharedSetter>>;
   onAck: (key: string) => void;
 }
 
@@ -82,8 +110,8 @@ function SharedStateSlice({
 
   stateMapRef.current.set(stateKey, value);
 
-  const setterRef = useRef((next: JSONSerializable | null) => setValue(next));
-  setterRef.current = (next: JSONSerializable | null) => setValue(next);
+  const setterRef = useRef<SharedSetter>((next) => setValue(next));
+  setterRef.current = (next) => setValue(next);
   settersRef.current.set(stateKey, (next) => setterRef.current(next));
 
   useEffect(() => {
@@ -96,19 +124,56 @@ function SharedStateSlice({
 interface ExposePhopApiInnerProps {
   registeredSlices: SliceRegistration[];
   onRegister: (key: string, strategy: SerializedStrategy) => void;
+  labelProbeEnabled: boolean;
+  onEnableLabelProbe: () => void;
 }
 
-function ExposePhopApiInner({ registeredSlices, onRegister }: ExposePhopApiInnerProps) {
+interface LabelProbeProps {
+  stateRef: React.RefObject<{ label: string; color: string }>;
+  actionsRef: React.RefObject<{ setLabel: (value: string) => void; cycleColor: () => void } | null>;
+  onReady: () => void;
+}
+
+function LabelProbe({ stateRef, actionsRef, onReady }: LabelProbeProps) {
+  // Intentionally mirrors the example usage: multiple selector subscriptions.
+  const label = useLabelStore((s) => s.label);
+  const color = useLabelStore((s) => s.color);
+  const setLabel = useLabelStore((s) => s.setLabel);
+  const cycleColor = useLabelStore((s) => s.cycleColor);
+
+  stateRef.current = { label, color };
+  actionsRef.current = { setLabel, cycleColor };
+
+  useEffect(() => {
+    onReady();
+  }, [onReady]);
+
+  return null;
+}
+
+function ExposePhopApiInner({
+  registeredSlices,
+  onRegister,
+  labelProbeEnabled,
+  onEnableLabelProbe,
+}: ExposePhopApiInnerProps) {
   const { peerId, peers, isConnected, broadcast, sendToPeer, onMessage, onPeerConnected } =
     useRoom();
 
   const stateMapRef = useRef<Map<string, JSONSerializable | null>>(new Map());
-  const settersRef = useRef<Map<string, (value: JSONSerializable | null) => void>>(new Map());
+  const settersRef = useRef<Map<string, SharedSetter>>(new Map());
   // Stable queue ref — never reset across re-renders so messages are never dropped.
   const msgQueueRef = useRef<
     Array<{ senderId: string; data: JSONSerializable; timestamp: number }>
   >([]);
   const pendingAcksRef = useRef<Map<string, Array<() => void>>>(new Map());
+  const labelProbeStateRef = useRef<{ label: string; color: string }>({ label: '', color: '' });
+  const labelProbeActionsRef = useRef<{
+    setLabel: (value: string) => void;
+    cycleColor: () => void;
+  } | null>(null);
+  const labelProbeReadyRef = useRef(false);
+  const pendingLabelProbeAcksRef = useRef<Array<() => void>>([]);
   // Tracks peers with an open data channel (incremented by onPeerConnected).
   const connectedPeerCountRef = useRef(0);
 
@@ -119,6 +184,15 @@ function ExposePhopApiInner({ registeredSlices, onRegister }: ExposePhopApiInner
         cb();
       }
       pendingAcksRef.current.delete(key);
+    }
+  }, []);
+
+  const handleLabelProbeReady = useCallback(() => {
+    labelProbeReadyRef.current = true;
+    const callbacks = pendingLabelProbeAcksRef.current;
+    pendingLabelProbeAcksRef.current = [];
+    for (const cb of callbacks) {
+      cb();
     }
   }, []);
 
@@ -180,8 +254,53 @@ function ExposePhopApiInner({ registeredSlices, onRegister }: ExposePhopApiInner
         setter(value);
       },
 
+      incrementSharedState: (key, delta = 1) => {
+        const setter = settersRef.current.get(key);
+        if (!setter) {
+          throw new Error(
+            `No shared state registered for key "${key}". Call registerSharedState first.`
+          );
+        }
+        setter((prev) => (((prev as number | null) ?? 0) + delta) as JSONSerializable);
+      },
+
       getSharedState: (key) => {
         return stateMapRef.current.get(key) ?? null;
+      },
+
+      enableLabelProbe: () => {
+        return new Promise<void>((resolve) => {
+          if (labelProbeReadyRef.current) {
+            resolve();
+            return;
+          }
+          pendingLabelProbeAcksRef.current.push(resolve);
+          onEnableLabelProbe();
+        });
+      },
+
+      setLabelText: (value) => {
+        const actions = labelProbeActionsRef.current;
+        if (!actions) {
+          throw new Error('Label probe is not ready. Call enableLabelProbe first.');
+        }
+        actions.setLabel(value);
+      },
+
+      typeLabelChar: (char) => {
+        if (char.length !== 1) {
+          throw new Error(`typeLabelChar expects a single character, received "${char}".`);
+        }
+        const actions = labelProbeActionsRef.current;
+        if (!actions) {
+          throw new Error('Label probe is not ready. Call enableLabelProbe first.');
+        }
+        const next = `${labelProbeStateRef.current.label}${char}`;
+        actions.setLabel(next);
+      },
+
+      getLabelText: () => {
+        return labelProbeStateRef.current.label;
       },
 
       __msgQueue: msgQueueRef.current,
@@ -219,6 +338,7 @@ function ExposePhopApiInner({ registeredSlices, onRegister }: ExposePhopApiInner
     registeredSlices,
     onRegister,
     handleAck,
+    onEnableLabelProbe,
   ]);
 
   return (
@@ -233,12 +353,20 @@ function ExposePhopApiInner({ registeredSlices, onRegister }: ExposePhopApiInner
           onAck={handleAck}
         />
       ))}
+      {labelProbeEnabled && (
+        <LabelProbe
+          stateRef={labelProbeStateRef}
+          actionsRef={labelProbeActionsRef}
+          onReady={handleLabelProbeReady}
+        />
+      )}
     </>
   );
 }
 
 export function ExposePhopApi() {
   const [registeredSlices, setRegisteredSlices] = useState<SliceRegistration[]>([]);
+  const [labelProbeEnabled, setLabelProbeEnabled] = useState(false);
 
   const handleRegister = (key: string, strategy: SerializedStrategy) => {
     setRegisteredSlices((prev) => {
@@ -247,5 +375,16 @@ export function ExposePhopApi() {
     });
   };
 
-  return <ExposePhopApiInner registeredSlices={registeredSlices} onRegister={handleRegister} />;
+  const handleEnableLabelProbe = () => {
+    setLabelProbeEnabled(true);
+  };
+
+  return (
+    <ExposePhopApiInner
+      registeredSlices={registeredSlices}
+      onRegister={handleRegister}
+      labelProbeEnabled={labelProbeEnabled}
+      onEnableLabelProbe={handleEnableLabelProbe}
+    />
+  );
 }

--- a/packages/integration-tests/harness/src/exposePhopApi.tsx
+++ b/packages/integration-tests/harness/src/exposePhopApi.tsx
@@ -1,8 +1,8 @@
 import {
-  createSharedStore,
   createConsensusStrategy,
   createLamportStrategy,
   createLastWriteWinsStrategy,
+  createSharedStore,
   type JSONSerializable,
   type MergeStrategy,
   useRoom,

--- a/packages/integration-tests/tests/helpers/PeerHandle.ts
+++ b/packages/integration-tests/tests/helpers/PeerHandle.ts
@@ -98,6 +98,37 @@ export class PeerHandle {
     return this.page.evaluate((k: string) => window.__phop.getSharedState(k), key);
   }
 
+  incrementSharedState(key: string, delta = 1): Promise<void> {
+    return this.page.evaluate(
+      ([k, d]: [string, number]) => window.__phop.incrementSharedState(k, d),
+      [key, delta] as [string, number]
+    );
+  }
+
+  enableLabelProbe(): Promise<void> {
+    return this.page.evaluate(() => window.__phop.enableLabelProbe());
+  }
+
+  setLabelText(value: string): Promise<void> {
+    return this.page.evaluate((v: string) => window.__phop.setLabelText(v), value);
+  }
+
+  typeLabelChar(char: string): Promise<void> {
+    return this.page.evaluate((c: string) => window.__phop.typeLabelChar(c), char);
+  }
+
+  getLabelText(): Promise<string> {
+    return this.page.evaluate(() => window.__phop.getLabelText());
+  }
+
+  async waitForLabelText(value: string, options?: { timeout?: number }): Promise<void> {
+    await this.page.waitForFunction(
+      (expected: string) => window.__phop.getLabelText() === expected,
+      value,
+      { timeout: options?.timeout ?? DEFAULT_TIMEOUT }
+    );
+  }
+
   /**
    * Polls until the shared state for `key` satisfies `predicate`.
    */

--- a/packages/integration-tests/tests/helpers/createRoom.ts
+++ b/packages/integration-tests/tests/helpers/createRoom.ts
@@ -1,7 +1,7 @@
 import type { Browser } from '@playwright/test';
 import { PeerHandle } from './PeerHandle';
 
-const HARNESS_URL = 'http://localhost:9000';
+const HARNESS_URL = process.env.HARNESS_URL ?? 'http://localhost:9000';
 const DEFAULT_SERVER_URL = 'ws://localhost:8080';
 
 interface CreateRoomOptions {

--- a/packages/integration-tests/tests/scenarios/sharedCounterWithStore.test.ts
+++ b/packages/integration-tests/tests/scenarios/sharedCounterWithStore.test.ts
@@ -1,0 +1,43 @@
+import { expect, test } from '@playwright/test';
+import { createRoom } from '../helpers/createRoom';
+
+test.describe('shared counter with shared-store label', () => {
+  test('counter updates locally and remotely while label store is mounted', async ({ browser }) => {
+    const [a, b] = await createRoom(browser, 2);
+
+    try {
+      await Promise.all([
+        a.registerSharedState('counter', 'lamport'),
+        b.registerSharedState('counter', 'lamport'),
+      ]);
+      await Promise.all([a.enableLabelProbe(), b.enableLabelProbe()]);
+
+      await a.setSharedState('counter', 0);
+      await a.waitForSharedState('counter', (v) => v === 0);
+      await b.waitForSharedState('counter', (v) => v === 0);
+
+      // Simulate example "+" button semantics: setCount(prev => prev + 1).
+      await a.incrementSharedState('counter', 1);
+      await a.waitForSharedState('counter', (v) => v === 1);
+      await b.waitForSharedState('counter', (v) => v === 1);
+
+      await b.incrementSharedState('counter', 1);
+      await a.waitForSharedState('counter', (v) => v === 2);
+      await b.waitForSharedState('counter', (v) => v === 2);
+
+      // Exercise label typing in-between to ensure no cross-feature regression.
+      await a.typeLabelChar('x');
+      await a.waitForLabelText('x');
+      await b.waitForLabelText('x');
+
+      await a.incrementSharedState('counter', 1);
+      await a.waitForSharedState('counter', (v) => v === 3);
+      await b.waitForSharedState('counter', (v) => v === 3);
+
+      expect(await a.getSharedState('counter')).toBe(3);
+      expect(await b.getSharedState('counter')).toBe(3);
+    } finally {
+      await Promise.all([a.close(), b.close()]);
+    }
+  });
+});

--- a/packages/integration-tests/tests/scenarios/sharedStoreLabel.test.ts
+++ b/packages/integration-tests/tests/scenarios/sharedStoreLabel.test.ts
@@ -1,0 +1,68 @@
+import { expect, test } from '@playwright/test';
+import { createRoom } from '../helpers/createRoom';
+
+test.describe('createSharedStore label probe', () => {
+  test('local writer sees its own label update immediately', async ({ browser }) => {
+    const [a, b] = await createRoom(browser, 2);
+
+    try {
+      await Promise.all([a.enableLabelProbe(), b.enableLabelProbe()]);
+
+      await a.setLabelText('hello');
+
+      await a.waitForLabelText('hello');
+      await b.waitForLabelText('hello');
+
+      expect(await a.getLabelText()).toBe('hello');
+      expect(await b.getLabelText()).toBe('hello');
+    } finally {
+      await Promise.all([a.close(), b.close()]);
+    }
+  });
+
+  test('typing multiple chars on one peer accumulates text on both peers', async ({ browser }) => {
+    const [a, b] = await createRoom(browser, 2);
+
+    try {
+      await Promise.all([a.enableLabelProbe(), b.enableLabelProbe()]);
+
+      await a.typeLabelChar('a');
+      await a.waitForLabelText('a');
+      await b.waitForLabelText('a');
+
+      await a.typeLabelChar('b');
+      await a.waitForLabelText('ab');
+      await b.waitForLabelText('ab');
+
+      await a.typeLabelChar('c');
+      await a.waitForLabelText('abc');
+      await b.waitForLabelText('abc');
+
+      expect(await a.getLabelText()).toBe('abc');
+      expect(await b.getLabelText()).toBe('abc');
+    } finally {
+      await Promise.all([a.close(), b.close()]);
+    }
+  });
+
+  test('typing from second peer continues from current shared label', async ({ browser }) => {
+    const [a, b] = await createRoom(browser, 2);
+
+    try {
+      await Promise.all([a.enableLabelProbe(), b.enableLabelProbe()]);
+
+      await a.setLabelText('ab');
+      await a.waitForLabelText('ab');
+      await b.waitForLabelText('ab');
+
+      await b.typeLabelChar('c');
+      await a.waitForLabelText('abc');
+      await b.waitForLabelText('abc');
+
+      expect(await a.getLabelText()).toBe('abc');
+      expect(await b.getLabelText()).toBe('abc');
+    } finally {
+      await Promise.all([a.close(), b.close()]);
+    }
+  });
+});

--- a/packages/phop/README.md
+++ b/packages/phop/README.md
@@ -49,15 +49,57 @@ Establishes a WebRTC mesh with all peers in the given room.
 | `signallingServerUrl` | `string` | WebSocket URL of the signaling server |
 | `roomId` | `string` | Room identifier — peers sharing a room ID connect to each other |
 
-### `useSharedState(key, initialValue, options?)`
+### `useSharedState(key, initialValue, strategy?)`
 
-Shared state hook — works like `useState` but syncs across all peers in the room.
+Shared state hook — works like `useState` but syncs across all peers in the room. Best for simple, single-value state.
 
 ```ts
-const [value, setValue] = useSharedState<T>(key: string, initialValue: T, options?: {
-  mergeStrategy?: MergeStrategy; // default: lastWriteWins
-})
+const [value, setValue] = useSharedState<T>(key: string, initialValue: T, strategy?: MergeStrategy);
 ```
+
+### `createSharedStore(key, initializer, options?)`
+
+Define a Zustand-style store that syncs across peers. Define at module scope, use inside a `<Room>`.
+
+```tsx
+import { createSharedStore } from '@peterddod/phop';
+
+const useCounterStore = createSharedStore('counter', (set) => ({
+  count: 0,
+  increment: () => set((s) => ({ count: s.count + 1 })),
+}));
+
+function Counter() {
+  const count = useCounterStore((s) => s.count);
+  const increment = useCounterStore((s) => s.increment);
+  return <button onClick={increment}>Count: {count}</button>;
+}
+```
+
+The store state must be JSON-serializable by default. If your store includes non-serializable fields (like functions), provide a `partialize` option to extract the synced slice:
+
+```ts
+type State = { count: number; increment: () => void };
+type Synced = { count: number };
+
+const useStore = createSharedStore<State, Synced>('key', (set) => ({
+  count: 0,
+  increment: () => set((s) => ({ count: s.count + 1 })),
+}), {
+  partialize: (s) => ({ count: s.count }),
+});
+```
+
+A custom merge strategy can be passed via `options.strategy`. The default is a Lamport logical clock.
+
+#### `useSharedState` vs `createSharedStore`
+
+| | `useSharedState` | `createSharedStore` |
+|---|---|---|
+| **Mental model** | `useState` | Zustand `create` |
+| **Scope** | One value per key | Object with actions |
+| **Selectors** | No | Yes — fine-grained re-renders |
+| **Best for** | Simple shared values | App-level shared state with logic |
 
 ### `useRoom()`
 

--- a/packages/phop/README.md
+++ b/packages/phop/README.md
@@ -29,7 +29,7 @@ function Counter() {
   const [count, setCount] = useSharedState('count', 0);
 
   return (
-    <button onClick={() => setCount(count + 1)}>
+    <button onClick={() => setCount((prev) => (prev ?? 0) + 1)}>
       Count: {count}
     </button>
   );
@@ -54,7 +54,14 @@ Establishes a WebRTC mesh with all peers in the given room.
 Shared state hook — works like `useState` but syncs across all peers in the room. Best for simple, single-value state.
 
 ```ts
-const [value, setValue] = useSharedState<T>(key: string, initialValue: T, strategy?: MergeStrategy);
+const [value, setValue] = useSharedState<T>(
+  key: string,
+  initialValue: T,
+  strategy?: MergeStrategy
+);
+
+setValue(nextValue);
+setValue((prev) => deriveNext(prev));
 ```
 
 ### `createSharedStore(key, initializer, options?)`
@@ -76,7 +83,7 @@ function Counter() {
 }
 ```
 
-The store state must be JSON-serializable by default. If your store includes non-serializable fields (like functions), provide a `partialize` option to extract the synced slice:
+By default, `createSharedStore` syncs the state returned by `partialize` (or all non-function fields if `partialize` is omitted). You only need `partialize` when you want to explicitly control the synced slice or your state includes non-JSON-serializable values.
 
 ```ts
 type State = { count: number; increment: () => void };
@@ -90,7 +97,7 @@ const useStore = createSharedStore<State, Synced>('key', (set) => ({
 });
 ```
 
-A custom merge strategy can be passed via `options.strategy`. The default is a Lamport logical clock.
+A custom `MergeStrategy` can be passed via `options.strategy`. The default is a Lamport logical clock.
 
 #### `useSharedState` vs `createSharedStore`
 

--- a/packages/phop/package.json
+++ b/packages/phop/package.json
@@ -48,7 +48,6 @@
   },
   "devDependencies": {
     "@testing-library/react": "^16.3.2",
-    "@testing-library/react-hooks": "^8.0.1",
     "@types/react": "^19.1.9",
     "jsdom": "^29.0.1",
     "tsup": "^8.5.0",

--- a/packages/phop/package.json
+++ b/packages/phop/package.json
@@ -38,15 +38,21 @@
   },
   "scripts": {
     "build": "tsup src/index.ts --format cjs,esm --dts --sourcemap --clean",
-    "dev": "tsup src/index.ts --format cjs,esm --dts --sourcemap --watch"
+    "dev": "tsup src/index.ts --format cjs,esm --dts --sourcemap --watch",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "sideEffects": false,
   "peerDependencies": {
     "react": ">=18"
   },
   "devDependencies": {
+    "@testing-library/react": "^16.3.2",
+    "@testing-library/react-hooks": "^8.0.1",
     "@types/react": "^19.1.9",
+    "jsdom": "^29.0.1",
     "tsup": "^8.5.0",
-    "typescript": "^5.9.2"
+    "typescript": "^5.9.2",
+    "vitest": "^4.1.1"
   }
 }

--- a/packages/phop/src/__tests__/SharedStateController.test.ts
+++ b/packages/phop/src/__tests__/SharedStateController.test.ts
@@ -1,0 +1,252 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createLamportStrategy, type LamportMeta } from '../core/merge-strategies/lamport';
+import type { MergeStrategy } from '../core/merge-strategies/types';
+import { SharedStateController, type RoomHandle } from '../core/SharedStateController';
+import type { JSONSerializable } from '../types';
+
+// ---------------------------------------------------------------------------
+// Mock room
+// ---------------------------------------------------------------------------
+
+type MessageCallback = (msg: { senderId: string; data: JSONSerializable; timestamp: number }) => void;
+
+function createMockRoom(peerId = 'peer-1', peers: string[] = ['peer-1']): {
+  room: RoomHandle;
+  simulateMessage: (senderId: string, data: JSONSerializable) => void;
+  simulatePeerConnected: (remotePeerId: string) => void;
+} {
+  const messageHandlers = new Set<MessageCallback>();
+  const peerConnectedHandlers = new Set<(remotePeerId: string) => void>();
+
+  const room: RoomHandle = {
+    peerId,
+    peers,
+    broadcast: vi.fn(),
+    sendToPeer: vi.fn(),
+    onMessage: (handler) => {
+      const cb = handler as MessageCallback;
+      messageHandlers.add(cb);
+      return () => { messageHandlers.delete(cb); };
+    },
+    onPeerConnected: (handler) => {
+      peerConnectedHandlers.add(handler);
+      return () => { peerConnectedHandlers.delete(handler); };
+    },
+  };
+
+  return {
+    room,
+    simulateMessage: (senderId, data) => {
+      for (const h of messageHandlers) {
+        h({ senderId, data, timestamp: Date.now() });
+      }
+    },
+    simulatePeerConnected: (remotePeerId) => {
+      for (const h of peerConnectedHandlers) {
+        h(remotePeerId);
+      }
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function createTestController(
+  key = 'test-key',
+  initialState: JSONSerializable | null = null,
+  peerId = 'peer-1',
+) {
+  const mock = createMockRoom(peerId);
+  const strategy = createLamportStrategy(() => mock.room.peerId);
+  const controller = new SharedStateController(key, initialState, strategy, mock.room);
+  return { controller, ...mock, strategy };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('SharedStateController', () => {
+  it('returns initial state from getState()', () => {
+    const { controller } = createTestController('k', 42);
+    expect(controller.getState()).toBe(42);
+  });
+
+  it('notifies subscribers when local setState triggers a commit via strategy', () => {
+    const { controller } = createTestController('k', 0);
+    const listener = vi.fn();
+    controller.subscribe(listener);
+
+    controller.setState(1);
+
+    expect(listener).toHaveBeenCalled();
+    expect(controller.getState()).toBe(1);
+  });
+
+  it('subscribe returns an unsubscribe function', () => {
+    const { controller } = createTestController('k', 0);
+    const listener = vi.fn();
+    const unsub = controller.subscribe(listener);
+
+    controller.setState(1);
+    expect(listener).toHaveBeenCalledTimes(1);
+
+    unsub();
+    controller.setState(2);
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  it('getState() is referentially stable when state has not changed', () => {
+    const { controller } = createTestController('k', 'hello');
+    const a = controller.getState();
+    const b = controller.getState();
+    expect(a).toBe(b);
+  });
+
+  it('responds to state-request messages with current state', () => {
+    const { room, simulateMessage } = createTestController('k', 99, 'peer-1');
+
+    simulateMessage('peer-2', { type: 'state-request', key: 'k' });
+
+    expect(room.sendToPeer).toHaveBeenCalledWith(
+      'peer-2',
+      expect.objectContaining({
+        senderId: 'peer-1',
+        data: expect.objectContaining({ key: 'k', state: 99 }),
+      }),
+    );
+  });
+
+  it('ignores state-request messages for other keys', () => {
+    const { room, simulateMessage } = createTestController('k', 99);
+
+    simulateMessage('peer-2', { type: 'state-request', key: 'other-key' });
+
+    expect(room.sendToPeer).not.toHaveBeenCalled();
+  });
+
+  it('ignores messages from self', () => {
+    const { controller, simulateMessage } = createTestController('k', 0, 'peer-1');
+    const listener = vi.fn();
+    controller.subscribe(listener);
+
+    simulateMessage('peer-1', { key: 'k', state: 99, meta: { clock: 5, tiebreaker: 'peer-1' } });
+
+    expect(listener).not.toHaveBeenCalled();
+    expect(controller.getState()).toBe(0);
+  });
+
+  it('filters messages by key', () => {
+    const { controller, simulateMessage } = createTestController('k', 0, 'peer-1');
+    const listener = vi.fn();
+    controller.subscribe(listener);
+
+    simulateMessage('peer-2', { key: 'wrong', state: 99, meta: { clock: 5, tiebreaker: 'peer-2' } });
+
+    expect(listener).not.toHaveBeenCalled();
+    expect(controller.getState()).toBe(0);
+  });
+
+  it('accepts incoming state when remote clock wins', () => {
+    const { controller, simulateMessage } = createTestController('k', 0, 'peer-1');
+
+    // Remote peer has a higher Lamport clock.
+    simulateMessage('peer-2', { key: 'k', state: 42, meta: { clock: 10, tiebreaker: 'peer-2' } });
+
+    expect(controller.getState()).toBe(42);
+  });
+
+  it('strips key from SharedStatePayload before forwarding to strategy', () => {
+    // Verify the strategy receives { state, meta } (without key).
+    // We do this indirectly by checking that a remote update with a
+    // higher clock is accepted (the Lamport strategy relies on the
+    // stripped shape).
+    const { controller, simulateMessage } = createTestController('k', 0, 'peer-1');
+
+    simulateMessage('peer-2', {
+      key: 'k',
+      state: 'updated',
+      meta: { clock: 100, tiebreaker: 'peer-2' },
+    });
+
+    expect(controller.getState()).toBe('updated');
+  });
+
+  it('passes non-SharedStatePayload keyed messages intact to strategy', () => {
+    // Consensus-style messages have { key, type: 'propose', ... } but no
+    // state/meta. The controller should forward these intact.
+    let receivedData: JSONSerializable | null = null;
+
+    const customStrategy: MergeStrategy<JSONSerializable, LamportMeta> = {
+      initialMeta: { clock: 0, tiebreaker: '' },
+      connect(ctx) {
+        const unsub = ctx.onMessage((data) => {
+          receivedData = data;
+        });
+        const unsubWrite = ctx.onLocalWrite(() => {});
+        return () => { unsub(); unsubWrite(); };
+      },
+    };
+
+    const mock = createMockRoom('peer-1');
+    const controller = new SharedStateController('k', null, customStrategy, mock.room);
+
+    mock.simulateMessage('peer-2', { key: 'k', type: 'propose', round: 1 });
+
+    expect(receivedData).toEqual({ key: 'k', type: 'propose', round: 1 });
+    controller.destroy();
+  });
+
+  it('fires onPeersChanged handlers when syncRoom receives new peers', () => {
+    const mock = createMockRoom('peer-1', ['peer-1']);
+    const strategy = createLamportStrategy(() => 'peer-1');
+    const controller = new SharedStateController('k', 0, strategy, mock.room);
+
+    controller.destroy();
+
+    const peerChangeSpy = vi.fn<(peers: string[]) => void>();
+    const customStrategy: MergeStrategy<JSONSerializable, LamportMeta> = {
+      initialMeta: { clock: 0, tiebreaker: '' },
+      connect(ctx) {
+        const unsub = ctx.onPeersChanged(peerChangeSpy);
+        const unsubWrite = ctx.onLocalWrite(() => {});
+        return () => { unsub(); unsubWrite(); };
+      },
+    };
+
+    const mock2 = createMockRoom('peer-1', ['peer-1']);
+    const ctrl = new SharedStateController('k', 0, customStrategy, mock2.room);
+
+    const newPeers = ['peer-1', 'peer-2'];
+    ctrl.syncRoom({ ...mock2.room, peers: newPeers });
+
+    expect(peerChangeSpy).toHaveBeenCalledWith(newPeers);
+    ctrl.destroy();
+  });
+
+  it('broadcasts local state on peer connected', () => {
+    const { room, simulatePeerConnected } = createTestController('k', 'hello', 'peer-1');
+
+    simulatePeerConnected('peer-2');
+
+    expect(room.sendToPeer).toHaveBeenCalledWith(
+      'peer-2',
+      expect.objectContaining({
+        data: expect.objectContaining({ state: 'hello', key: 'k' }),
+      }),
+    );
+  });
+
+  it('cleans up on destroy', () => {
+    const { controller } = createTestController('k', 0);
+    const listener = vi.fn();
+    controller.subscribe(listener);
+
+    controller.destroy();
+    controller.setState(1);
+
+    expect(listener).not.toHaveBeenCalled();
+  });
+});

--- a/packages/phop/src/__tests__/SharedStateController.test.ts
+++ b/packages/phop/src/__tests__/SharedStateController.test.ts
@@ -72,6 +72,7 @@ function createTestController(
   const mock = createMockRoom(peerId);
   const strategy = createLamportStrategy(() => mock.room.peerId);
   const controller = new SharedStateController(key, initialState, strategy, mock.room);
+  controller.start();
   return { controller, ...mock, strategy };
 }
 
@@ -210,6 +211,7 @@ describe('SharedStateController', () => {
 
     const mock = createMockRoom('peer-1');
     const controller = new SharedStateController('k', null, customStrategy, mock.room);
+    controller.start();
 
     mock.simulateMessage('peer-2', { key: 'k', type: 'propose', round: 1 });
 
@@ -239,6 +241,7 @@ describe('SharedStateController', () => {
 
     const mock2 = createMockRoom('peer-1', ['peer-1']);
     const ctrl = new SharedStateController('k', 0, customStrategy, mock2.room);
+    ctrl.start();
 
     const newPeers = ['peer-1', 'peer-2'];
     ctrl.syncRoom({ ...mock2.room, peers: newPeers });

--- a/packages/phop/src/__tests__/SharedStateController.test.ts
+++ b/packages/phop/src/__tests__/SharedStateController.test.ts
@@ -1,16 +1,23 @@
 import { describe, expect, it, vi } from 'vitest';
 import { createLamportStrategy, type LamportMeta } from '../core/merge-strategies/lamport';
 import type { MergeStrategy } from '../core/merge-strategies/types';
-import { SharedStateController, type RoomHandle } from '../core/SharedStateController';
+import { type RoomHandle, SharedStateController } from '../core/SharedStateController';
 import type { JSONSerializable } from '../types';
 
 // ---------------------------------------------------------------------------
 // Mock room
 // ---------------------------------------------------------------------------
 
-type MessageCallback = (msg: { senderId: string; data: JSONSerializable; timestamp: number }) => void;
+type MessageCallback = (msg: {
+  senderId: string;
+  data: JSONSerializable;
+  timestamp: number;
+}) => void;
 
-function createMockRoom(peerId = 'peer-1', peers: string[] = ['peer-1']): {
+function createMockRoom(
+  peerId = 'peer-1',
+  peers: string[] = ['peer-1']
+): {
   room: RoomHandle;
   simulateMessage: (senderId: string, data: JSONSerializable) => void;
   simulatePeerConnected: (remotePeerId: string) => void;
@@ -26,11 +33,15 @@ function createMockRoom(peerId = 'peer-1', peers: string[] = ['peer-1']): {
     onMessage: (handler) => {
       const cb = handler as MessageCallback;
       messageHandlers.add(cb);
-      return () => { messageHandlers.delete(cb); };
+      return () => {
+        messageHandlers.delete(cb);
+      };
     },
     onPeerConnected: (handler) => {
       peerConnectedHandlers.add(handler);
-      return () => { peerConnectedHandlers.delete(handler); };
+      return () => {
+        peerConnectedHandlers.delete(handler);
+      };
     },
   };
 
@@ -56,7 +67,7 @@ function createMockRoom(peerId = 'peer-1', peers: string[] = ['peer-1']): {
 function createTestController(
   key = 'test-key',
   initialState: JSONSerializable | null = null,
-  peerId = 'peer-1',
+  peerId = 'peer-1'
 ) {
   const mock = createMockRoom(peerId);
   const strategy = createLamportStrategy(() => mock.room.peerId);
@@ -115,7 +126,7 @@ describe('SharedStateController', () => {
       expect.objectContaining({
         senderId: 'peer-1',
         data: expect.objectContaining({ key: 'k', state: 99 }),
-      }),
+      })
     );
   });
 
@@ -143,7 +154,11 @@ describe('SharedStateController', () => {
     const listener = vi.fn();
     controller.subscribe(listener);
 
-    simulateMessage('peer-2', { key: 'wrong', state: 99, meta: { clock: 5, tiebreaker: 'peer-2' } });
+    simulateMessage('peer-2', {
+      key: 'wrong',
+      state: 99,
+      meta: { clock: 5, tiebreaker: 'peer-2' },
+    });
 
     expect(listener).not.toHaveBeenCalled();
     expect(controller.getState()).toBe(0);
@@ -186,7 +201,10 @@ describe('SharedStateController', () => {
           receivedData = data;
         });
         const unsubWrite = ctx.onLocalWrite(() => {});
-        return () => { unsub(); unsubWrite(); };
+        return () => {
+          unsub();
+          unsubWrite();
+        };
       },
     };
 
@@ -212,7 +230,10 @@ describe('SharedStateController', () => {
       connect(ctx) {
         const unsub = ctx.onPeersChanged(peerChangeSpy);
         const unsubWrite = ctx.onLocalWrite(() => {});
-        return () => { unsub(); unsubWrite(); };
+        return () => {
+          unsub();
+          unsubWrite();
+        };
       },
     };
 
@@ -235,7 +256,7 @@ describe('SharedStateController', () => {
       'peer-2',
       expect.objectContaining({
         data: expect.objectContaining({ state: 'hello', key: 'k' }),
-      }),
+      })
     );
   });
 

--- a/packages/phop/src/__tests__/createSharedStore.test.tsx
+++ b/packages/phop/src/__tests__/createSharedStore.test.tsx
@@ -21,6 +21,7 @@ function createMockRoomContext(peerId = 'peer-1', peers: string[] = ['peer-1']):
     sendToPeer: vi.fn(),
     onMessage: vi.fn(() => () => {}),
     onPeerConnected: vi.fn(() => () => {}),
+    __internalStoreRegistry: new Map(),
   };
 
   const wrapper: React.FC<PropsWithChildren> = ({ children }) => (
@@ -241,6 +242,7 @@ describe('createSharedStore', () => {
         sendToPeer: vi.fn(),
         onMessage: vi.fn(() => () => {}),
         onPeerConnected: vi.fn(() => () => {}),
+        __internalStoreRegistry: new Map(),
       } as RoomContextValue,
     };
 
@@ -259,5 +261,53 @@ describe('createSharedStore', () => {
 
     const broadcastCall = (state.current.broadcast as ReturnType<typeof vi.fn>).mock.calls[0][0];
     expect(broadcastCall.data.meta).toEqual(expect.objectContaining({ tiebreaker: 'peer-1' }));
+  });
+
+  it('selector subscriptions avoid unrelated re-renders', () => {
+    const { wrapper } = createMockRoomContext();
+
+    interface State {
+      count: number;
+      name: string;
+      increment: () => void;
+    }
+
+    const useStore = createSharedStore<State>('counter', (set) => ({
+      count: 0,
+      name: 'alice',
+      increment: () => set((s) => ({ count: s.count + 1 })),
+    }));
+
+    let countRenders = 0;
+    let nameRenders = 0;
+
+    const countHook = renderHook(
+      () => {
+        countRenders += 1;
+        return useStore((s) => s.count);
+      },
+      { wrapper },
+    );
+
+    const nameHook = renderHook(
+      () => {
+        nameRenders += 1;
+        return useStore((s) => s.name);
+      },
+      { wrapper },
+    );
+
+    const actionHook = renderHook(() => useStore((s) => s.increment), { wrapper });
+
+    const initialNameRenders = nameRenders;
+
+    act(() => {
+      actionHook.result.current();
+    });
+
+    expect(countHook.result.current).toBe(1);
+    expect(nameHook.result.current).toBe('alice');
+    expect(countRenders).toBeGreaterThan(1);
+    expect(nameRenders).toBe(initialNameRenders);
   });
 });

--- a/packages/phop/src/__tests__/createSharedStore.test.tsx
+++ b/packages/phop/src/__tests__/createSharedStore.test.tsx
@@ -1,54 +1,9 @@
 import { act, renderHook } from '@testing-library/react';
-import { type PropsWithChildren, StrictMode } from 'react';
+import type { PropsWithChildren } from 'react';
 import { describe, expect, it, vi } from 'vitest';
 import { RoomContext, type RoomContextValue } from '../context/Room';
 import { createSharedStore } from '../store';
-
-// ---------------------------------------------------------------------------
-// Mock room context wrapper
-// ---------------------------------------------------------------------------
-
-function createMockRoomContext(
-  peerId = 'peer-1',
-  peers: string[] = ['peer-1']
-): {
-  value: RoomContextValue;
-  wrapper: React.FC<PropsWithChildren>;
-} {
-  const value: RoomContextValue = {
-    roomId: 'test-room',
-    peerId,
-    peers,
-    isConnected: true,
-    broadcast: vi.fn(),
-    sendToPeer: vi.fn(),
-    onMessage: vi.fn(() => () => {}),
-    onPeerConnected: vi.fn(() => () => {}),
-    __internalStoreRegistry: new Map(),
-  };
-
-  const wrapper: React.FC<PropsWithChildren> = ({ children }) => (
-    <RoomContext.Provider value={value}>{children}</RoomContext.Provider>
-  );
-
-  return { value, wrapper };
-}
-
-function createStrictMockRoomContext(
-  peerId = 'peer-1',
-  peers: string[] = ['peer-1']
-): {
-  value: RoomContextValue;
-  wrapper: React.FC<PropsWithChildren>;
-} {
-  const { value, wrapper: BaseWrapper } = createMockRoomContext(peerId, peers);
-  const wrapper: React.FC<PropsWithChildren> = ({ children }) => (
-    <StrictMode>
-      <BaseWrapper>{children}</BaseWrapper>
-    </StrictMode>
-  );
-  return { value, wrapper };
-}
+import { createMockRoomContext, createStrictMockRoomContext } from './helpers/mockRoomContext';
 
 // ---------------------------------------------------------------------------
 // Tests

--- a/packages/phop/src/__tests__/createSharedStore.test.tsx
+++ b/packages/phop/src/__tests__/createSharedStore.test.tsx
@@ -1,5 +1,5 @@
 import { act, renderHook } from '@testing-library/react';
-import { StrictMode, type PropsWithChildren } from 'react';
+import { type PropsWithChildren, StrictMode } from 'react';
 import { describe, expect, it, vi } from 'vitest';
 import { RoomContext, type RoomContextValue } from '../context/Room';
 import { createSharedStore } from '../store';
@@ -8,7 +8,10 @@ import { createSharedStore } from '../store';
 // Mock room context wrapper
 // ---------------------------------------------------------------------------
 
-function createMockRoomContext(peerId = 'peer-1', peers: string[] = ['peer-1']): {
+function createMockRoomContext(
+  peerId = 'peer-1',
+  peers: string[] = ['peer-1']
+): {
   value: RoomContextValue;
   wrapper: React.FC<PropsWithChildren>;
 } {
@@ -31,7 +34,10 @@ function createMockRoomContext(peerId = 'peer-1', peers: string[] = ['peer-1']):
   return { value, wrapper };
 }
 
-function createStrictMockRoomContext(peerId = 'peer-1', peers: string[] = ['peer-1']): {
+function createStrictMockRoomContext(
+  peerId = 'peer-1',
+  peers: string[] = ['peer-1']
+): {
   value: RoomContextValue;
   wrapper: React.FC<PropsWithChildren>;
 } {
@@ -159,7 +165,7 @@ describe('createSharedStore', () => {
         count: 0,
         increment: () => set((s) => ({ count: s.count + 1 })),
       }),
-      { partialize: (s) => ({ count: s.count }) },
+      { partialize: (s) => ({ count: s.count }) }
     );
 
     const { result } = renderHook(() => useStore(), { wrapper });
@@ -286,7 +292,7 @@ describe('createSharedStore', () => {
         countRenders += 1;
         return useStore((s) => s.count);
       },
-      { wrapper },
+      { wrapper }
     );
 
     const nameHook = renderHook(
@@ -294,7 +300,7 @@ describe('createSharedStore', () => {
         nameRenders += 1;
         return useStore((s) => s.name);
       },
-      { wrapper },
+      { wrapper }
     );
 
     const actionHook = renderHook(() => useStore((s) => s.increment), { wrapper });

--- a/packages/phop/src/__tests__/createSharedStore.test.tsx
+++ b/packages/phop/src/__tests__/createSharedStore.test.tsx
@@ -1,0 +1,263 @@
+import { act, renderHook } from '@testing-library/react';
+import { StrictMode, type PropsWithChildren } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { RoomContext, type RoomContextValue } from '../context/Room';
+import { createSharedStore } from '../store';
+
+// ---------------------------------------------------------------------------
+// Mock room context wrapper
+// ---------------------------------------------------------------------------
+
+function createMockRoomContext(peerId = 'peer-1', peers: string[] = ['peer-1']): {
+  value: RoomContextValue;
+  wrapper: React.FC<PropsWithChildren>;
+} {
+  const value: RoomContextValue = {
+    roomId: 'test-room',
+    peerId,
+    peers,
+    isConnected: true,
+    broadcast: vi.fn(),
+    sendToPeer: vi.fn(),
+    onMessage: vi.fn(() => () => {}),
+    onPeerConnected: vi.fn(() => () => {}),
+  };
+
+  const wrapper: React.FC<PropsWithChildren> = ({ children }) => (
+    <RoomContext.Provider value={value}>{children}</RoomContext.Provider>
+  );
+
+  return { value, wrapper };
+}
+
+function createStrictMockRoomContext(peerId = 'peer-1', peers: string[] = ['peer-1']): {
+  value: RoomContextValue;
+  wrapper: React.FC<PropsWithChildren>;
+} {
+  const { value, wrapper: BaseWrapper } = createMockRoomContext(peerId, peers);
+  const wrapper: React.FC<PropsWithChildren> = ({ children }) => (
+    <StrictMode>
+      <BaseWrapper>{children}</BaseWrapper>
+    </StrictMode>
+  );
+  return { value, wrapper };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('createSharedStore', () => {
+  it('returns initial state from the initializer (no set usage — type inferred)', () => {
+    const { wrapper } = createMockRoomContext();
+    const useStore = createSharedStore('counter', () => ({ count: 0 }));
+
+    const { result } = renderHook(() => useStore(), { wrapper });
+
+    expect(result.current).toEqual({ count: 0 });
+  });
+
+  it('updates state via set(partial)', () => {
+    const { wrapper } = createMockRoomContext();
+
+    interface CounterState {
+      count: number;
+      increment: () => void;
+    }
+
+    const useStore = createSharedStore<CounterState>('counter', (set) => ({
+      count: 0,
+      increment: () => set((s) => ({ count: s.count + 1 })),
+    }));
+
+    const { result } = renderHook(() => useStore(), { wrapper });
+
+    act(() => {
+      result.current.increment();
+    });
+
+    expect(result.current.count).toBe(1);
+  });
+
+  it('supports selectors for fine-grained subscriptions', () => {
+    const { wrapper } = createMockRoomContext();
+
+    interface State {
+      count: number;
+      name: string;
+      increment: () => void;
+    }
+
+    const useStore = createSharedStore<State>('counter', (set) => ({
+      count: 0,
+      name: 'test',
+      increment: () => set((s) => ({ count: s.count + 1 })),
+    }));
+
+    const { result } = renderHook(() => useStore((s) => s.count), { wrapper });
+
+    expect(result.current).toBe(0);
+  });
+
+  it('get() returns current state inside set()', () => {
+    const { wrapper } = createMockRoomContext();
+
+    interface CounterState {
+      count: number;
+      doubleIncrement: () => void;
+    }
+
+    const useStore = createSharedStore<CounterState>('counter', (set, get) => ({
+      count: 0,
+      doubleIncrement: () => {
+        set({ count: get().count + 1 });
+        set({ count: get().count + 1 });
+      },
+    }));
+
+    const { result } = renderHook(() => useStore(), { wrapper });
+
+    act(() => {
+      result.current.doubleIncrement();
+    });
+
+    expect(result.current.count).toBe(2);
+  });
+
+  it('broadcasts on local set', () => {
+    const { wrapper, value } = createMockRoomContext();
+
+    interface CounterState {
+      count: number;
+      increment: () => void;
+    }
+
+    const useStore = createSharedStore<CounterState>('counter', (set) => ({
+      count: 0,
+      increment: () => set((s) => ({ count: s.count + 1 })),
+    }));
+
+    const { result } = renderHook(() => useStore(), { wrapper });
+
+    act(() => {
+      result.current.increment();
+    });
+
+    expect(value.broadcast).toHaveBeenCalled();
+  });
+
+  it('works with explicit partialize option', () => {
+    const { wrapper } = createMockRoomContext();
+
+    type State = { count: number; increment: () => void };
+    type Synced = { count: number };
+
+    const useStore = createSharedStore<State, Synced>(
+      'counter',
+      (set) => ({
+        count: 0,
+        increment: () => set((s) => ({ count: s.count + 1 })),
+      }),
+      { partialize: (s) => ({ count: s.count }) },
+    );
+
+    const { result } = renderHook(() => useStore(), { wrapper });
+
+    act(() => {
+      result.current.increment();
+    });
+
+    expect(result.current.count).toBe(1);
+    expect(typeof result.current.increment).toBe('function');
+  });
+
+  it('auto-strips functions when no partialize is provided', () => {
+    const { wrapper, value } = createMockRoomContext();
+
+    interface CounterState {
+      count: number;
+      increment: () => void;
+    }
+
+    const useStore = createSharedStore<CounterState>('counter', (set) => ({
+      count: 0,
+      increment: () => set((s) => ({ count: s.count + 1 })),
+    }));
+
+    const { result } = renderHook(() => useStore(), { wrapper });
+
+    act(() => {
+      result.current.increment();
+    });
+
+    // The broadcast payload should not contain the increment function.
+    const broadcastCall = (value.broadcast as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    const syncedData = broadcastCall.data;
+    expect(syncedData.state).toEqual({ count: 1 });
+    expect(syncedData.state.increment).toBeUndefined();
+  });
+
+  it('works under StrictMode without duplicating local broadcasts', () => {
+    const { wrapper, value } = createStrictMockRoomContext();
+
+    interface CounterState {
+      count: number;
+      increment: () => void;
+    }
+
+    const useStore = createSharedStore<CounterState>('counter', (set) => ({
+      count: 0,
+      increment: () => set((s) => ({ count: s.count + 1 })),
+    }));
+
+    const { result } = renderHook(() => useStore(), { wrapper });
+
+    act(() => {
+      result.current.increment();
+    });
+
+    expect(value.broadcast).toHaveBeenCalledTimes(1);
+    expect(result.current.count).toBe(1);
+  });
+
+  it('uses latest peerId in Lamport metadata after initial empty peerId', () => {
+    interface CounterState {
+      count: number;
+      increment: () => void;
+    }
+
+    const useStore = createSharedStore<CounterState>('counter', (set) => ({
+      count: 0,
+      increment: () => set((s) => ({ count: s.count + 1 })),
+    }));
+
+    const state = {
+      current: {
+        roomId: 'test-room',
+        peerId: '',
+        peers: ['peer-1'],
+        isConnected: true,
+        broadcast: vi.fn(),
+        sendToPeer: vi.fn(),
+        onMessage: vi.fn(() => () => {}),
+        onPeerConnected: vi.fn(() => () => {}),
+      } as RoomContextValue,
+    };
+
+    const wrapper: React.FC<PropsWithChildren> = ({ children }) => (
+      <RoomContext.Provider value={state.current}>{children}</RoomContext.Provider>
+    );
+
+    const { result, rerender } = renderHook(() => useStore(), { wrapper });
+
+    state.current = { ...state.current, peerId: 'peer-1' };
+    rerender();
+
+    act(() => {
+      result.current.increment();
+    });
+
+    const broadcastCall = (state.current.broadcast as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(broadcastCall.data.meta).toEqual(expect.objectContaining({ tiebreaker: 'peer-1' }));
+  });
+});

--- a/packages/phop/src/__tests__/helpers/mockRoomContext.tsx
+++ b/packages/phop/src/__tests__/helpers/mockRoomContext.tsx
@@ -1,0 +1,45 @@
+import { type PropsWithChildren, StrictMode } from 'react';
+import { vi } from 'vitest';
+import { RoomContext, type RoomContextValue } from '../../context/Room';
+
+export function createMockRoomContext(
+  peerId = 'peer-1',
+  peers: string[] = ['peer-1']
+): {
+  value: RoomContextValue;
+  wrapper: React.FC<PropsWithChildren>;
+} {
+  const value: RoomContextValue = {
+    roomId: 'test-room',
+    peerId,
+    peers,
+    isConnected: true,
+    broadcast: vi.fn(),
+    sendToPeer: vi.fn(),
+    onMessage: vi.fn(() => () => {}),
+    onPeerConnected: vi.fn(() => () => {}),
+    __internalStoreRegistry: new Map(),
+  };
+
+  const wrapper: React.FC<PropsWithChildren> = ({ children }) => (
+    <RoomContext.Provider value={value}>{children}</RoomContext.Provider>
+  );
+
+  return { value, wrapper };
+}
+
+export function createStrictMockRoomContext(
+  peerId = 'peer-1',
+  peers: string[] = ['peer-1']
+): {
+  value: RoomContextValue;
+  wrapper: React.FC<PropsWithChildren>;
+} {
+  const { value, wrapper: BaseWrapper } = createMockRoomContext(peerId, peers);
+  const wrapper: React.FC<PropsWithChildren> = ({ children }) => (
+    <StrictMode>
+      <BaseWrapper>{children}</BaseWrapper>
+    </StrictMode>
+  );
+  return { value, wrapper };
+}

--- a/packages/phop/src/__tests__/useSharedState.test.tsx
+++ b/packages/phop/src/__tests__/useSharedState.test.tsx
@@ -1,11 +1,14 @@
 import { act, renderHook } from '@testing-library/react';
-import { StrictMode, type PropsWithChildren } from 'react';
+import { type PropsWithChildren, StrictMode } from 'react';
 import { describe, expect, it, vi } from 'vitest';
 import { RoomContext, type RoomContextValue } from '../context/Room';
 import type { MergeStrategy } from '../core/merge-strategies';
 import { useSharedState } from '../hooks/useSharedState';
 
-function createMockRoomContext(peerId = 'peer-1', peers: string[] = ['peer-1']): {
+function createMockRoomContext(
+  peerId = 'peer-1',
+  peers: string[] = ['peer-1']
+): {
   value: RoomContextValue;
   wrapper: React.FC<PropsWithChildren>;
 } {
@@ -27,7 +30,10 @@ function createMockRoomContext(peerId = 'peer-1', peers: string[] = ['peer-1']):
   return { value, wrapper };
 }
 
-function createStrictMockRoomContext(peerId = 'peer-1', peers: string[] = ['peer-1']): {
+function createStrictMockRoomContext(
+  peerId = 'peer-1',
+  peers: string[] = ['peer-1']
+): {
   value: RoomContextValue;
   wrapper: React.FC<PropsWithChildren>;
 } {
@@ -86,7 +92,9 @@ describe('useSharedState', () => {
       <RoomContext.Provider value={state.current}>{children}</RoomContext.Provider>
     );
 
-    const { result, rerender } = renderHook(() => useSharedState<number>('counter', 0), { wrapper });
+    const { result, rerender } = renderHook(() => useSharedState<number>('counter', 0), {
+      wrapper,
+    });
 
     state.current = { ...state.current, peerId: 'peer-1' };
     rerender();
@@ -139,9 +147,12 @@ describe('useSharedState', () => {
     );
 
     try {
-      const { rerender } = renderHook(() => useSharedState<number, { seen: number }>('counter', 0, strategy), {
-        wrapper,
-      });
+      const { rerender } = renderHook(
+        () => useSharedState<number, { seen: number }>('counter', 0, strategy),
+        {
+          wrapper,
+        }
+      );
 
       state.current = { ...state.current, peers: ['peer-1', 'peer-2'] };
       rerender();
@@ -150,12 +161,12 @@ describe('useSharedState', () => {
         (c) =>
           c[0]?.data &&
           typeof c[0].data === 'object' &&
-          (c[0].data as Record<string, unknown>).type === 'peers-changed',
+          (c[0].data as Record<string, unknown>).type === 'peers-changed'
       );
       expect(peerChangedCalls).toHaveLength(1);
 
       const renderWarning = errorSpy.mock.calls.some((args) =>
-        String(args[0] ?? '').includes('Cannot update a component while rendering'),
+        String(args[0] ?? '').includes('Cannot update a component while rendering')
       );
       expect(renderWarning).toBe(false);
     } finally {

--- a/packages/phop/src/__tests__/useSharedState.test.tsx
+++ b/packages/phop/src/__tests__/useSharedState.test.tsx
@@ -35,35 +35,23 @@ describe('useSharedState', () => {
   });
 
   it('uses latest peerId in Lamport metadata after initial empty peerId', () => {
-    const state = {
-      current: {
-        roomId: 'test-room',
-        peerId: '',
-        peers: ['peer-1'],
-        isConnected: true,
-        broadcast: vi.fn(),
-        sendToPeer: vi.fn(),
-        onMessage: vi.fn(() => () => {}),
-        onPeerConnected: vi.fn(() => () => {}),
-      } as RoomContextValue,
-    };
-
+    const { value, wrapper: BaseWrapper } = createMockRoomContext('', ['peer-1']);
     const wrapper: React.FC<PropsWithChildren> = ({ children }) => (
-      <RoomContext.Provider value={state.current}>{children}</RoomContext.Provider>
+      <BaseWrapper>{children}</BaseWrapper>
     );
 
     const { result, rerender } = renderHook(() => useSharedState<number>('counter', 0), {
       wrapper,
     });
 
-    state.current = { ...state.current, peerId: 'peer-1' };
+    value.peerId = 'peer-1';
     rerender();
 
     act(() => {
       result.current[1](1);
     });
 
-    const broadcastCall = (state.current.broadcast as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    const broadcastCall = (value.broadcast as ReturnType<typeof vi.fn>).mock.calls[0][0];
     expect(broadcastCall.data.meta).toEqual(expect.objectContaining({ tiebreaker: 'peer-1' }));
   });
 

--- a/packages/phop/src/__tests__/useSharedState.test.tsx
+++ b/packages/phop/src/__tests__/useSharedState.test.tsx
@@ -2,6 +2,7 @@ import { act, renderHook } from '@testing-library/react';
 import { StrictMode, type PropsWithChildren } from 'react';
 import { describe, expect, it, vi } from 'vitest';
 import { RoomContext, type RoomContextValue } from '../context/Room';
+import type { MergeStrategy } from '../core/merge-strategies';
 import { useSharedState } from '../hooks/useSharedState';
 
 function createMockRoomContext(peerId = 'peer-1', peers: string[] = ['peer-1']): {
@@ -96,5 +97,69 @@ describe('useSharedState', () => {
 
     const broadcastCall = (state.current.broadcast as ReturnType<typeof vi.fn>).mock.calls[0][0];
     expect(broadcastCall.data.meta).toEqual(expect.objectContaining({ tiebreaker: 'peer-1' }));
+  });
+
+  it('syncs peers in StrictMode without duplicate peer-change side effects', () => {
+    const broadcast = vi.fn();
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const strategy: MergeStrategy<number, { seen: number }> = {
+      initialMeta: { seen: 0 },
+      connect(ctx) {
+        const unsubLocal = ctx.onLocalWrite((state) => {
+          ctx.commit(state, { seen: 0 });
+        });
+        const unsubPeers = ctx.onPeersChanged((peers) => {
+          ctx.broadcast({ type: 'peers-changed', count: peers.length });
+        });
+        return () => {
+          unsubLocal();
+          unsubPeers();
+        };
+      },
+    };
+
+    const state = {
+      current: {
+        roomId: 'test-room',
+        peerId: 'peer-1',
+        peers: ['peer-1'],
+        isConnected: true,
+        broadcast,
+        sendToPeer: vi.fn(),
+        onMessage: vi.fn(() => () => {}),
+        onPeerConnected: vi.fn(() => () => {}),
+      } as RoomContextValue,
+    };
+
+    const wrapper: React.FC<PropsWithChildren> = ({ children }) => (
+      <StrictMode>
+        <RoomContext.Provider value={state.current}>{children}</RoomContext.Provider>
+      </StrictMode>
+    );
+
+    try {
+      const { rerender } = renderHook(() => useSharedState<number, { seen: number }>('counter', 0, strategy), {
+        wrapper,
+      });
+
+      state.current = { ...state.current, peers: ['peer-1', 'peer-2'] };
+      rerender();
+
+      const peerChangedCalls = broadcast.mock.calls.filter(
+        (c) =>
+          c[0]?.data &&
+          typeof c[0].data === 'object' &&
+          (c[0].data as Record<string, unknown>).type === 'peers-changed',
+      );
+      expect(peerChangedCalls).toHaveLength(1);
+
+      const renderWarning = errorSpy.mock.calls.some((args) =>
+        String(args[0] ?? '').includes('Cannot update a component while rendering'),
+      );
+      expect(renderWarning).toBe(false);
+    } finally {
+      errorSpy.mockRestore();
+    }
   });
 });

--- a/packages/phop/src/__tests__/useSharedState.test.tsx
+++ b/packages/phop/src/__tests__/useSharedState.test.tsx
@@ -1,0 +1,100 @@
+import { act, renderHook } from '@testing-library/react';
+import { StrictMode, type PropsWithChildren } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { RoomContext, type RoomContextValue } from '../context/Room';
+import { useSharedState } from '../hooks/useSharedState';
+
+function createMockRoomContext(peerId = 'peer-1', peers: string[] = ['peer-1']): {
+  value: RoomContextValue;
+  wrapper: React.FC<PropsWithChildren>;
+} {
+  const value: RoomContextValue = {
+    roomId: 'test-room',
+    peerId,
+    peers,
+    isConnected: true,
+    broadcast: vi.fn(),
+    sendToPeer: vi.fn(),
+    onMessage: vi.fn(() => () => {}),
+    onPeerConnected: vi.fn(() => () => {}),
+  };
+
+  const wrapper: React.FC<PropsWithChildren> = ({ children }) => (
+    <RoomContext.Provider value={value}>{children}</RoomContext.Provider>
+  );
+
+  return { value, wrapper };
+}
+
+function createStrictMockRoomContext(peerId = 'peer-1', peers: string[] = ['peer-1']): {
+  value: RoomContextValue;
+  wrapper: React.FC<PropsWithChildren>;
+} {
+  const { value, wrapper: BaseWrapper } = createMockRoomContext(peerId, peers);
+  const wrapper: React.FC<PropsWithChildren> = ({ children }) => (
+    <StrictMode>
+      <BaseWrapper>{children}</BaseWrapper>
+    </StrictMode>
+  );
+  return { value, wrapper };
+}
+
+describe('useSharedState', () => {
+  it('supports functional updater form like useState', () => {
+    const { value, wrapper } = createMockRoomContext();
+    const { result } = renderHook(() => useSharedState<number>('counter', 0), { wrapper });
+
+    act(() => {
+      result.current[1]((prev) => (prev ?? 0) + 1);
+    });
+
+    expect(result.current[0]).toBe(1);
+    const broadcastCall = (value.broadcast as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(broadcastCall.data.state).toBe(1);
+    expect(typeof broadcastCall.data.state).toBe('number');
+  });
+
+  it('works under StrictMode without duplicating local broadcasts', () => {
+    const { value, wrapper } = createStrictMockRoomContext();
+
+    const { result } = renderHook(() => useSharedState<number>('counter', 0), { wrapper });
+
+    act(() => {
+      result.current[1](1);
+    });
+
+    expect(value.broadcast).toHaveBeenCalledTimes(1);
+    expect(result.current[0]).toBe(1);
+  });
+
+  it('uses latest peerId in Lamport metadata after initial empty peerId', () => {
+    const state = {
+      current: {
+        roomId: 'test-room',
+        peerId: '',
+        peers: ['peer-1'],
+        isConnected: true,
+        broadcast: vi.fn(),
+        sendToPeer: vi.fn(),
+        onMessage: vi.fn(() => () => {}),
+        onPeerConnected: vi.fn(() => () => {}),
+      } as RoomContextValue,
+    };
+
+    const wrapper: React.FC<PropsWithChildren> = ({ children }) => (
+      <RoomContext.Provider value={state.current}>{children}</RoomContext.Provider>
+    );
+
+    const { result, rerender } = renderHook(() => useSharedState<number>('counter', 0), { wrapper });
+
+    state.current = { ...state.current, peerId: 'peer-1' };
+    rerender();
+
+    act(() => {
+      result.current[1](1);
+    });
+
+    const broadcastCall = (state.current.broadcast as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(broadcastCall.data.meta).toEqual(expect.objectContaining({ tiebreaker: 'peer-1' }));
+  });
+});

--- a/packages/phop/src/__tests__/useSharedState.test.tsx
+++ b/packages/phop/src/__tests__/useSharedState.test.tsx
@@ -36,12 +36,9 @@ describe('useSharedState', () => {
 
   it('uses latest peerId in Lamport metadata after initial empty peerId', () => {
     const { value, wrapper: BaseWrapper } = createMockRoomContext('', ['peer-1']);
-    const wrapper: React.FC<PropsWithChildren> = ({ children }) => (
-      <BaseWrapper>{children}</BaseWrapper>
-    );
 
     const { result, rerender } = renderHook(() => useSharedState<number>('counter', 0), {
-      wrapper,
+      wrapper: BaseWrapper,
     });
 
     value.peerId = 'peer-1';

--- a/packages/phop/src/__tests__/useSharedState.test.tsx
+++ b/packages/phop/src/__tests__/useSharedState.test.tsx
@@ -4,47 +4,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { RoomContext, type RoomContextValue } from '../context/Room';
 import type { MergeStrategy } from '../core/merge-strategies';
 import { useSharedState } from '../hooks/useSharedState';
-
-function createMockRoomContext(
-  peerId = 'peer-1',
-  peers: string[] = ['peer-1']
-): {
-  value: RoomContextValue;
-  wrapper: React.FC<PropsWithChildren>;
-} {
-  const value: RoomContextValue = {
-    roomId: 'test-room',
-    peerId,
-    peers,
-    isConnected: true,
-    broadcast: vi.fn(),
-    sendToPeer: vi.fn(),
-    onMessage: vi.fn(() => () => {}),
-    onPeerConnected: vi.fn(() => () => {}),
-  };
-
-  const wrapper: React.FC<PropsWithChildren> = ({ children }) => (
-    <RoomContext.Provider value={value}>{children}</RoomContext.Provider>
-  );
-
-  return { value, wrapper };
-}
-
-function createStrictMockRoomContext(
-  peerId = 'peer-1',
-  peers: string[] = ['peer-1']
-): {
-  value: RoomContextValue;
-  wrapper: React.FC<PropsWithChildren>;
-} {
-  const { value, wrapper: BaseWrapper } = createMockRoomContext(peerId, peers);
-  const wrapper: React.FC<PropsWithChildren> = ({ children }) => (
-    <StrictMode>
-      <BaseWrapper>{children}</BaseWrapper>
-    </StrictMode>
-  );
-  return { value, wrapper };
-}
+import { createMockRoomContext, createStrictMockRoomContext } from './helpers/mockRoomContext';
 
 describe('useSharedState', () => {
   it('supports functional updater form like useState', () => {

--- a/packages/phop/src/context/Room.tsx
+++ b/packages/phop/src/context/Room.tsx
@@ -40,7 +40,12 @@ export function Room({ children, signallingServerUrl, roomId }: RoomProps) {
   const connectionsRef = useRef<Map<string, PeerConnection>>(new Map());
   const handlersRef = useRef<Set<MessageHandler>>(new Set());
   const peerConnectedHandlersRef = useRef<Set<(remotePeerId: string) => void>>(new Set());
-  const internalStoreRegistryRef = useRef<Map<string, unknown>>(new Map());
+  const internalStoreRegistriesRef = useRef<Map<string, Map<string, unknown>>>(new Map());
+  let internalStoreRegistry = internalStoreRegistriesRef.current.get(roomId);
+  if (!internalStoreRegistry) {
+    internalStoreRegistry = new Map<string, unknown>();
+    internalStoreRegistriesRef.current.set(roomId, internalStoreRegistry);
+  }
 
   useEffect(
     function initializeSignalingClient() {
@@ -205,7 +210,7 @@ export function Room({ children, signallingServerUrl, roomId }: RoomProps) {
     sendToPeer,
     onMessage,
     onPeerConnected,
-    __internalStoreRegistry: internalStoreRegistryRef.current,
+    __internalStoreRegistry: internalStoreRegistry,
   };
 
   return <RoomContext.Provider value={contextValue}>{children}</RoomContext.Provider>;

--- a/packages/phop/src/context/Room.tsx
+++ b/packages/phop/src/context/Room.tsx
@@ -17,6 +17,11 @@ export interface RoomContextValue {
     handler: MessageHandler<TData>
   ) => () => void;
   onPeerConnected: (handler: (remotePeerId: string) => void) => () => void;
+  /**
+   * Internal registry used by createSharedStore so every hook call in a Room
+   * shares one store instance per key.
+   */
+  __internalStoreRegistry?: Map<string, unknown>;
 }
 
 export const RoomContext = createContext<RoomContextValue | null>(null);
@@ -35,6 +40,7 @@ export function Room({ children, signallingServerUrl, roomId }: RoomProps) {
   const connectionsRef = useRef<Map<string, PeerConnection>>(new Map());
   const handlersRef = useRef<Set<MessageHandler>>(new Set());
   const peerConnectedHandlersRef = useRef<Set<(remotePeerId: string) => void>>(new Set());
+  const internalStoreRegistryRef = useRef<Map<string, unknown>>(new Map());
 
   useEffect(
     function initializeSignalingClient() {
@@ -199,6 +205,7 @@ export function Room({ children, signallingServerUrl, roomId }: RoomProps) {
     sendToPeer,
     onMessage,
     onPeerConnected,
+    __internalStoreRegistry: internalStoreRegistryRef.current,
   };
 
   return <RoomContext.Provider value={contextValue}>{children}</RoomContext.Provider>;

--- a/packages/phop/src/core/SharedStateController.ts
+++ b/packages/phop/src/core/SharedStateController.ts
@@ -1,0 +1,258 @@
+import type { JSONSerializable, Message, MessageHandler } from '../types';
+import type { MergeMeta, MergeStrategy, StrategyContext } from './merge-strategies/types';
+import { isSharedStatePayload, isStateRequest } from './shared-state-protocol';
+
+/**
+ * Subset of RoomContextValue that the controller needs. Using a narrow
+ * interface avoids coupling the controller to React context directly.
+ */
+export interface RoomHandle {
+  peerId: string;
+  peers: string[];
+  broadcast: <TData extends JSONSerializable = JSONSerializable>(message: Message<TData>) => void;
+  sendToPeer: <TData extends JSONSerializable = JSONSerializable>(
+    peerId: string,
+    message: Message<TData>
+  ) => void;
+  onMessage: <TData extends JSONSerializable = JSONSerializable>(
+    handler: MessageHandler<TData>
+  ) => () => void;
+  onPeerConnected: (handler: (remotePeerId: string) => void) => () => void;
+}
+
+type Listener = () => void;
+type SetStateAction<TState> = TState | ((prev: TState) => TState);
+
+/**
+ * Manages the full lifecycle of a single shared-state key: strategy
+ * connection, message dispatch, state-request handling, and subscriber
+ * notification. Framework-agnostic — React binding happens in the hook layer.
+ */
+export class SharedStateController<
+  TState extends JSONSerializable = JSONSerializable,
+  TMeta extends MergeMeta = MergeMeta,
+> {
+  private state: TState | null;
+  private meta: TMeta;
+  private readonly key: string;
+  private readonly strategy: MergeStrategy<TState, TMeta>;
+
+  // Mutable room fields, updated via syncRoom().
+  private peerId = '';
+  private peers: string[] = [];
+  private broadcast!: RoomHandle['broadcast'];
+  private sendToPeer!: RoomHandle['sendToPeer'];
+  private onMessage!: RoomHandle['onMessage'];
+  private onPeerConnected!: RoomHandle['onPeerConnected'];
+
+  // Strategy handler sets.
+  private readonly localWriteHandlers = new Set<(state: TState | null) => void>();
+  private readonly messageHandlers = new Set<
+    (data: JSONSerializable, senderId: string) => void
+  >();
+  private readonly peersChangedHandlers = new Set<(peers: string[]) => void>();
+
+  // External subscribers (useSyncExternalStore / store API).
+  private readonly listeners = new Set<Listener>();
+
+  private strategyCleanup: (() => void) | null = null;
+  private messageUnsubscribe: (() => void) | null = null;
+  private destroyed = false;
+
+  constructor(
+    key: string,
+    initialState: TState | null,
+    strategy: MergeStrategy<TState, TMeta>,
+    room: RoomHandle,
+  ) {
+    this.key = key;
+    this.state = initialState;
+    this.meta = strategy.initialMeta;
+    this.strategy = strategy;
+
+    this.applyRoom(room);
+    this.connectStrategy();
+    this.subscribeToMessages();
+  }
+
+  // -------------------------------------------------------------------
+  // Public API
+  // -------------------------------------------------------------------
+
+  getState = (): TState | null => this.state;
+
+  getMeta = (): TMeta => this.meta;
+
+  setState = (next: SetStateAction<TState | null>): void => {
+    const resolved = typeof next === 'function' ? (next as (prev: TState | null) => TState | null)(this.state) : next;
+    for (const handler of this.localWriteHandlers) {
+      handler(resolved);
+    }
+  };
+
+  /**
+   * Subscribe to state changes. Returns an unsubscribe function.
+   * Compatible with `useSyncExternalStore`.
+   */
+  subscribe = (listener: Listener): (() => void) => {
+    this.listeners.add(listener);
+    return () => {
+      this.listeners.delete(listener);
+    };
+  };
+
+  /**
+   * Push latest room fields into the controller. Call on every render
+   * so the strategy always sees current values without re-subscription.
+   */
+  syncRoom(room: RoomHandle): void {
+    const prevPeers = this.peers;
+
+    this.applyRoom(room);
+
+    if (prevPeers !== room.peers) {
+      for (const handler of this.peersChangedHandlers) {
+        handler(room.peers);
+      }
+    }
+  }
+
+  destroy(): void {
+    if (this.destroyed) return;
+    this.destroyed = true;
+    this.strategyCleanup?.();
+    this.messageUnsubscribe?.();
+    this.localWriteHandlers.clear();
+    this.messageHandlers.clear();
+    this.peersChangedHandlers.clear();
+    this.listeners.clear();
+  }
+
+  // -------------------------------------------------------------------
+  // Internals
+  // -------------------------------------------------------------------
+
+  private applyRoom(room: RoomHandle): void {
+    this.peerId = room.peerId;
+    this.peers = room.peers;
+    this.broadcast = room.broadcast;
+    this.sendToPeer = room.sendToPeer;
+    this.onMessage = room.onMessage;
+    this.onPeerConnected = room.onPeerConnected;
+  }
+
+  private notify(): void {
+    for (const listener of this.listeners) {
+      listener();
+    }
+  }
+
+  private connectStrategy(): void {
+    // Arrow methods on `this` close over the instance, but the peerId
+    // getter on StrategyContext must be a plain property accessor — capture
+    // `this` so the object-literal getter can reach it.
+    // biome-ignore lint/correctness/noUnusedVariables: captured by getter closure
+    const self = this;
+
+    const ctx: StrategyContext<TState, TMeta> = {
+      get peerId() {
+        return self.peerId;
+      },
+      getPeers: () => this.peers,
+      getState: () => this.state,
+      getMeta: () => this.meta,
+
+      broadcast: (data) => {
+        if (typeof data !== 'object' || data === null || Array.isArray(data)) {
+          throw new Error('ctx.broadcast: data must be a plain object');
+        }
+        this.broadcast({
+          senderId: this.peerId,
+          data: { ...(data as Record<string, JSONSerializable>), key: this.key },
+          timestamp: Date.now(),
+        });
+      },
+
+      sendToPeer: (targetPeerId, data) => {
+        if (typeof data !== 'object' || data === null || Array.isArray(data)) {
+          throw new Error('ctx.sendToPeer: data must be a plain object');
+        }
+        this.sendToPeer(targetPeerId, {
+          senderId: this.peerId,
+          data: { ...(data as Record<string, JSONSerializable>), key: this.key },
+          timestamp: Date.now(),
+        });
+      },
+
+      onMessage: (handler) => {
+        this.messageHandlers.add(handler);
+        return () => {
+          this.messageHandlers.delete(handler);
+        };
+      },
+
+      onPeersChanged: (handler) => {
+        this.peersChangedHandlers.add(handler);
+        return () => {
+          this.peersChangedHandlers.delete(handler);
+        };
+      },
+
+      onPeerConnected: (handler) => {
+        return this.onPeerConnected(handler);
+      },
+
+      commit: (state, meta) => {
+        this.state = state;
+        this.meta = meta;
+        this.notify();
+      },
+
+      onLocalWrite: (handler) => {
+        this.localWriteHandlers.add(handler);
+        return () => {
+          this.localWriteHandlers.delete(handler);
+        };
+      },
+    };
+
+    this.strategyCleanup = this.strategy.connect(ctx);
+  }
+
+  private subscribeToMessages(): void {
+    this.messageUnsubscribe = this.onMessage(({ senderId, data }) => {
+      if (senderId === this.peerId) return;
+
+      if (isStateRequest(data)) {
+        if (data.key === this.key) {
+          this.sendToPeer(senderId, {
+            senderId: this.peerId,
+            data: {
+              key: this.key,
+              state: this.state,
+              meta: this.meta,
+            } as JSONSerializable,
+            timestamp: Date.now(),
+          });
+        }
+        return;
+      }
+
+      if (typeof data !== 'object' || data === null) return;
+      const keyed = data as Record<string, JSONSerializable>;
+      if (keyed.key !== this.key) return;
+
+      // For standard state payloads strip the namespace key before forwarding
+      // so strategies receive a consistent { state, meta } shape. For other
+      // keyed protocol messages (e.g. consensus rounds) forward the full
+      // payload so strategies can dispatch on their own message type field.
+      const forwarded: JSONSerializable = isSharedStatePayload(data)
+        ? ({ state: data.state, meta: data.meta } as JSONSerializable)
+        : (keyed as JSONSerializable);
+
+      for (const handler of this.messageHandlers) {
+        handler(forwarded, senderId);
+      }
+    });
+  }
+}

--- a/packages/phop/src/core/SharedStateController.ts
+++ b/packages/phop/src/core/SharedStateController.ts
@@ -55,6 +55,7 @@ export class SharedStateController<
 
   private strategyCleanup: (() => void) | null = null;
   private messageUnsubscribe: (() => void) | null = null;
+  private started = false;
   private destroyed = false;
 
   constructor(
@@ -69,8 +70,12 @@ export class SharedStateController<
     this.strategy = strategy;
 
     this.applyRoom(room);
+  }
+  start(): void {
+    if (this.destroyed || this.started) return;
     this.connectStrategy();
     this.subscribeToMessages();
+    this.started = true;
   }
 
   // -------------------------------------------------------------------
@@ -107,9 +112,23 @@ export class SharedStateController<
    * so the strategy always sees current values without re-subscription.
    */
   syncRoom(room: RoomHandle): void {
+    const prevOnMessage = this.onMessage;
+    const prevOnPeerConnected = this.onPeerConnected;
     const prevPeers = this.peers;
 
     this.applyRoom(room);
+
+    if (
+      this.started &&
+      (prevOnMessage !== room.onMessage || prevOnPeerConnected !== room.onPeerConnected)
+    ) {
+      this.strategyCleanup?.();
+      this.strategyCleanup = null;
+      this.messageUnsubscribe?.();
+      this.messageUnsubscribe = null;
+      this.connectStrategy();
+      this.subscribeToMessages();
+    }
 
     if (prevPeers !== room.peers) {
       for (const handler of this.peersChangedHandlers) {
@@ -121,8 +140,11 @@ export class SharedStateController<
   destroy(): void {
     if (this.destroyed) return;
     this.destroyed = true;
+    this.started = false;
     this.strategyCleanup?.();
+    this.strategyCleanup = null;
     this.messageUnsubscribe?.();
+    this.messageUnsubscribe = null;
     this.localWriteHandlers.clear();
     this.messageHandlers.clear();
     this.peersChangedHandlers.clear();

--- a/packages/phop/src/core/SharedStateController.ts
+++ b/packages/phop/src/core/SharedStateController.ts
@@ -47,9 +47,7 @@ export class SharedStateController<
 
   // Strategy handler sets.
   private readonly localWriteHandlers = new Set<(state: TState | null) => void>();
-  private readonly messageHandlers = new Set<
-    (data: JSONSerializable, senderId: string) => void
-  >();
+  private readonly messageHandlers = new Set<(data: JSONSerializable, senderId: string) => void>();
   private readonly peersChangedHandlers = new Set<(peers: string[]) => void>();
 
   // External subscribers (useSyncExternalStore / store API).
@@ -63,7 +61,7 @@ export class SharedStateController<
     key: string,
     initialState: TState | null,
     strategy: MergeStrategy<TState, TMeta>,
-    room: RoomHandle,
+    room: RoomHandle
   ) {
     this.key = key;
     this.state = initialState;
@@ -84,7 +82,10 @@ export class SharedStateController<
   getMeta = (): TMeta => this.meta;
 
   setState = (next: SetStateAction<TState | null>): void => {
-    const resolved = typeof next === 'function' ? (next as (prev: TState | null) => TState | null)(this.state) : next;
+    const resolved =
+      typeof next === 'function'
+        ? (next as (prev: TState | null) => TState | null)(this.state)
+        : next;
     for (const handler of this.localWriteHandlers) {
       handler(resolved);
     }
@@ -151,7 +152,6 @@ export class SharedStateController<
     // Arrow methods on `this` close over the instance, but the peerId
     // getter on StrategyContext must be a plain property accessor — capture
     // `this` so the object-literal getter can reach it.
-    // biome-ignore lint/correctness/noUnusedVariables: captured by getter closure
     const self = this;
 
     const ctx: StrategyContext<TState, TMeta> = {

--- a/packages/phop/src/core/shared-state-protocol.ts
+++ b/packages/phop/src/core/shared-state-protocol.ts
@@ -1,0 +1,28 @@
+import type { JSONSerializable } from '../types';
+import type { MergeMeta } from './merge-strategies/types';
+
+export type StateRequestPayload = {
+  type: 'state-request';
+  key: string;
+};
+
+export type SharedStatePayload = {
+  key: string;
+  state: JSONSerializable | null;
+  meta: MergeMeta;
+};
+
+export function isStateRequest(data: unknown): data is StateRequestPayload {
+  return (
+    typeof data === 'object' &&
+    data !== null &&
+    'type' in data &&
+    (data as StateRequestPayload).type === 'state-request'
+  );
+}
+
+export function isSharedStatePayload(data: unknown): data is SharedStatePayload {
+  if (typeof data !== 'object' || data === null) return false;
+  const d = data as Record<string, unknown>;
+  return typeof d.key === 'string' && 'state' in d && typeof d.meta === 'object' && d.meta !== null;
+}

--- a/packages/phop/src/core/shared-state-protocol.ts
+++ b/packages/phop/src/core/shared-state-protocol.ts
@@ -13,16 +13,19 @@ export type SharedStatePayload = {
 };
 
 export function isStateRequest(data: unknown): data is StateRequestPayload {
-  return (
-    typeof data === 'object' &&
-    data !== null &&
-    'type' in data &&
-    (data as StateRequestPayload).type === 'state-request'
-  );
+  if (typeof data !== 'object' || data === null) return false;
+  const d = data as Record<string, unknown>;
+  return d.type === 'state-request' && typeof d.key === 'string';
 }
 
 export function isSharedStatePayload(data: unknown): data is SharedStatePayload {
   if (typeof data !== 'object' || data === null) return false;
   const d = data as Record<string, unknown>;
-  return typeof d.key === 'string' && 'state' in d && typeof d.meta === 'object' && d.meta !== null;
+  return (
+    typeof d.key === 'string' &&
+    'state' in d &&
+    d.state !== undefined &&
+    typeof d.meta === 'object' &&
+    d.meta !== null
+  );
 }

--- a/packages/phop/src/hooks/useSharedState.ts
+++ b/packages/phop/src/hooks/useSharedState.ts
@@ -1,39 +1,15 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useSyncExternalStore } from 'react';
 import {
   createLamportStrategy,
   type LamportMeta,
   type MergeMeta,
   type MergeStrategy,
 } from '../core/merge-strategies';
-import type { StrategyContext } from '../core/merge-strategies/types';
+import { SharedStateController } from '../core/SharedStateController';
 import type { JSONSerializable } from '../types';
 import { useRoom } from './useRoom';
 
-type StateRequestPayload = {
-  type: 'state-request';
-  key: string;
-};
-
-type SharedStatePayload = {
-  key: string;
-  state: JSONSerializable | null;
-  meta: MergeMeta;
-};
-
-function isStateRequest(data: unknown): data is StateRequestPayload {
-  return (
-    typeof data === 'object' &&
-    data !== null &&
-    'type' in data &&
-    (data as StateRequestPayload).type === 'state-request'
-  );
-}
-
-function isSharedStatePayload(data: unknown): data is SharedStatePayload {
-  if (typeof data !== 'object' || data === null) return false;
-  const d = data as Record<string, unknown>;
-  return typeof d.key === 'string' && 'state' in d && typeof d.meta === 'object' && d.meta !== null;
-}
+type SetStateAction<TState> = TState | ((prev: TState) => TState);
 
 /**
  * A hook that allows you to share state between multiple peers.
@@ -52,7 +28,7 @@ function isSharedStatePayload(data: unknown): data is SharedStatePayload {
 export function useSharedState<TState extends JSONSerializable>(
   key: string,
   initialState: TState | null
-): [state: TState | null, setState: (next: TState | null) => void];
+): [state: TState | null, setState: (next: SetStateAction<TState | null>) => void];
 
 /**
  * A hook that allows you to share state between multiple peers with a custom merge strategy.
@@ -66,7 +42,7 @@ export function useSharedState<TState extends JSONSerializable, TMeta extends Me
   key: string,
   initialState: TState | null,
   strategy: MergeStrategy<TState, TMeta>
-): [state: TState | null, setState: (next: TState | null) => void];
+): [state: TState | null, setState: (next: SetStateAction<TState | null>) => void];
 
 export function useSharedState<
   TState extends JSONSerializable,
@@ -75,23 +51,10 @@ export function useSharedState<
   key: string,
   initialState: TState | null,
   strategy?: MergeStrategy<TState, TMeta>
-): [state: TState | null, setState: (next: TState | null) => void] {
-  const { broadcast, onMessage, onPeerConnected, peers, peerId, sendToPeer } = useRoom();
-
-  const peerIdRef = useRef(peerId);
-  peerIdRef.current = peerId;
-
-  const peersRef = useRef(peers);
-  peersRef.current = peers;
-
-  const broadcastRef = useRef(broadcast);
-  broadcastRef.current = broadcast;
-
-  const sendToPeerRef = useRef(sendToPeer);
-  sendToPeerRef.current = sendToPeer;
-
-  const onPeerConnectedRef = useRef(onPeerConnected);
-  onPeerConnectedRef.current = onPeerConnected;
+): [state: TState | null, setState: (next: SetStateAction<TState | null>) => void] {
+  const room = useRoom();
+  const peerIdRef = useRef(room.peerId);
+  peerIdRef.current = room.peerId;
 
   const lamportStrategyRef = useRef<MergeStrategy<JSONSerializable, LamportMeta>>(
     createLamportStrategy(() => peerIdRef.current)
@@ -102,152 +65,46 @@ export function useSharedState<
       ? strategy
       : (lamportStrategyRef.current as unknown as MergeStrategy<TState, TMeta>);
 
-  const [rawState, setRawState] = useState<TState | null>(initialState);
-  const rawStateRef = useRef<TState | null>(initialState);
-  const rawStateMetaRef = useRef<TMeta>(effectiveStrategy.initialMeta);
+  const controllerRef = useRef<SharedStateController<TState, TMeta> | null>(null);
 
-  rawStateRef.current = rawState;
+  // Create / recreate controller when key or strategy changes.
+  // We track prev values to detect changes and destroy the old controller.
+  const prevKeyRef = useRef(key);
+  const prevStrategyRef = useRef(effectiveStrategy);
 
-  // Handlers registered by the strategy via ctx.onLocalWrite.
-  const localWriteHandlersRef = useRef<Set<(state: TState | null) => void>>(new Set());
+  if (
+    controllerRef.current === null ||
+    prevKeyRef.current !== key ||
+    prevStrategyRef.current !== effectiveStrategy
+  ) {
+    controllerRef.current?.destroy();
+    controllerRef.current = new SharedStateController(key, initialState, effectiveStrategy, room);
+    prevKeyRef.current = key;
+    prevStrategyRef.current = effectiveStrategy;
+  }
 
-  // Handlers registered by the strategy via ctx.onMessage (pre-filtered by key).
-  const messageHandlersRef = useRef<Set<(data: JSONSerializable, senderId: string) => void>>(
-    new Set()
-  );
+  const controller = controllerRef.current;
 
-  // Handlers registered by the strategy via ctx.onPeersChanged.
-  const peersChangedHandlersRef = useRef<Set<(peers: string[]) => void>>(new Set());
+  // Push latest room fields each render so the controller always has
+  // current values (peerId, peers, broadcast, etc.).
+  controller.syncRoom(room);
 
-  // Fire onPeersChanged handlers after render when the peers array reference changes.
-  const prevPeersRef = useRef<string[]>(peers);
+  // Destroy controller on unmount.
   useEffect(() => {
-    if (prevPeersRef.current !== peers) {
-      prevPeersRef.current = peers;
-      for (const handler of peersChangedHandlersRef.current) {
-        handler(peers);
-      }
-    }
-  }, [peers]);
-
-  useEffect(
-    function connectStrategy() {
-      const ctx: StrategyContext<TState, TMeta> = {
-        // Expose a getter so strategies always read the current peer ID, even
-        // if the signalling handshake completes after connect() runs.
-        get peerId() {
-          return peerIdRef.current;
-        },
-
-        getPeers: () => peersRef.current,
-        getState: () => rawStateRef.current,
-        getMeta: () => rawStateMetaRef.current,
-
-        broadcast: (data) => {
-          if (typeof data !== 'object' || data === null || Array.isArray(data)) {
-            throw new Error('ctx.broadcast: data must be a plain object');
-          }
-          broadcastRef.current({
-            senderId: peerIdRef.current,
-            // key is spread last so strategy payloads cannot overwrite the namespace.
-            data: { ...(data as Record<string, JSONSerializable>), key },
-            timestamp: Date.now(),
-          });
-        },
-
-        sendToPeer: (targetPeerId, data) => {
-          if (typeof data !== 'object' || data === null || Array.isArray(data)) {
-            throw new Error('ctx.sendToPeer: data must be a plain object');
-          }
-          sendToPeerRef.current(targetPeerId, {
-            senderId: peerIdRef.current,
-            // key is spread last so strategy payloads cannot overwrite the namespace.
-            data: { ...(data as Record<string, JSONSerializable>), key },
-            timestamp: Date.now(),
-          });
-        },
-
-        onMessage: (handler) => {
-          messageHandlersRef.current.add(handler);
-          return () => {
-            messageHandlersRef.current.delete(handler);
-          };
-        },
-
-        onPeersChanged: (handler) => {
-          peersChangedHandlersRef.current.add(handler);
-          return () => peersChangedHandlersRef.current.delete(handler);
-        },
-
-        onPeerConnected: (handler) => {
-          return onPeerConnectedRef.current(handler);
-        },
-
-        commit: (state, meta) => {
-          rawStateRef.current = state;
-          rawStateMetaRef.current = meta;
-          setRawState(state);
-        },
-
-        onLocalWrite: (handler) => {
-          localWriteHandlersRef.current.add(handler);
-          return () => localWriteHandlersRef.current.delete(handler);
-        },
-      };
-
-      const cleanup = effectiveStrategy.connect(ctx);
-      return cleanup;
-    },
-    [key, effectiveStrategy]
-  );
-
-  useEffect(
-    function handleMessage() {
-      const unsubscribe = onMessage(({ senderId, data }) => {
-        if (senderId === peerId) return;
-
-        if (isStateRequest(data)) {
-          if (data.key === key) {
-            sendToPeer(senderId, {
-              senderId: peerId,
-              data: {
-                key,
-                state: rawStateRef.current,
-                meta: rawStateMetaRef.current,
-              } as JSONSerializable,
-              timestamp: Date.now(),
-            });
-          }
-          return;
-        }
-
-        if (typeof data !== 'object' || data === null) return;
-        const keyed = data as Record<string, JSONSerializable>;
-        if (keyed.key !== key) return;
-
-        // For standard state payloads strip the namespace key before forwarding
-        // so strategies receive a consistent { state, meta } shape. For other
-        // keyed protocol messages (e.g. consensus rounds) forward the full
-        // payload so strategies can dispatch on their own message type field.
-        const forwarded: JSONSerializable = isSharedStatePayload(data)
-          ? ({ state: data.state, meta: data.meta } as JSONSerializable)
-          : (keyed as JSONSerializable);
-
-        for (const handler of messageHandlersRef.current) {
-          handler(forwarded, senderId);
-        }
-      });
-
-      return unsubscribe;
-    },
-    [key, onMessage, peerId, sendToPeer]
-  );
-
-  const setState = useCallback((next: TState | null): void => {
-    for (const handler of localWriteHandlersRef.current) {
-      handler(next);
-    }
+    return () => {
+      controllerRef.current?.destroy();
+      controllerRef.current = null;
+    };
   }, []);
 
-  return [rawState, setState];
+  const state = useSyncExternalStore(controller.subscribe, controller.getState, controller.getState);
+
+  const setState = useCallback(
+    (next: SetStateAction<TState | null>): void => {
+      controllerRef.current?.setState(next);
+    },
+    [],
+  );
+
+  return [state, setState];
 }

--- a/packages/phop/src/hooks/useSharedState.ts
+++ b/packages/phop/src/hooks/useSharedState.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useSyncExternalStore } from 'react';
+import { useCallback, useEffect, useLayoutEffect, useRef, useSyncExternalStore } from 'react';
 import {
   createLamportStrategy,
   type LamportMeta,
@@ -85,9 +85,10 @@ export function useSharedState<
 
   const controller = controllerRef.current;
 
-  // Push latest room fields each render so the controller always has
-  // current values (peerId, peers, broadcast, etc.).
-  controller.syncRoom(room);
+  // Keep controller room bindings in an effect to avoid render-phase side effects.
+  useLayoutEffect(() => {
+    controller.syncRoom(room);
+  }, [controller, room.peerId, room.peers, room.broadcast, room.sendToPeer, room.onMessage, room.onPeerConnected]);
 
   // Destroy controller on unmount.
   useEffect(() => {

--- a/packages/phop/src/hooks/useSharedState.ts
+++ b/packages/phop/src/hooks/useSharedState.ts
@@ -84,6 +84,7 @@ export function useSharedState<
       : (lamportStrategyRef.current as unknown as MergeStrategy<TState, TMeta>);
 
   const controllerRef = useRef<SharedStateController<TState, TMeta> | null>(null);
+  const pendingDestroyRef = useRef<SharedStateController<TState, TMeta> | null>(null);
 
   // Create / recreate controller when key or strategy changes.
   // We track prev values to detect changes and destroy the old controller.
@@ -95,7 +96,7 @@ export function useSharedState<
     prevKeyRef.current !== key ||
     prevStrategyRef.current !== effectiveStrategy
   ) {
-    controllerRef.current?.destroy();
+    pendingDestroyRef.current = controllerRef.current;
     controllerRef.current = new SharedStateController(
       key,
       initialState,
@@ -110,12 +111,17 @@ export function useSharedState<
 
   // Keep controller room bindings in an effect to avoid render-phase side effects.
   useLayoutEffect(() => {
+    pendingDestroyRef.current?.destroy();
+    pendingDestroyRef.current = null;
+    controller.start();
     controller.syncRoom(roomHandle);
   }, [controller, roomHandle]);
 
   // Destroy controller on unmount.
   useEffect(() => {
     return () => {
+      pendingDestroyRef.current?.destroy();
+      pendingDestroyRef.current = null;
       controllerRef.current?.destroy();
       controllerRef.current = null;
     };

--- a/packages/phop/src/hooks/useSharedState.ts
+++ b/packages/phop/src/hooks/useSharedState.ts
@@ -1,4 +1,11 @@
-import { useCallback, useEffect, useLayoutEffect, useRef, useSyncExternalStore } from 'react';
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useSyncExternalStore,
+} from 'react';
 import {
   createLamportStrategy,
   type LamportMeta,
@@ -53,6 +60,17 @@ export function useSharedState<
   strategy?: MergeStrategy<TState, TMeta>
 ): [state: TState | null, setState: (next: SetStateAction<TState | null>) => void] {
   const room = useRoom();
+  const roomHandle = useMemo(
+    () => ({
+      peerId: room.peerId,
+      peers: room.peers,
+      broadcast: room.broadcast,
+      sendToPeer: room.sendToPeer,
+      onMessage: room.onMessage,
+      onPeerConnected: room.onPeerConnected,
+    }),
+    [room]
+  );
   const peerIdRef = useRef(room.peerId);
   peerIdRef.current = room.peerId;
 
@@ -78,7 +96,12 @@ export function useSharedState<
     prevStrategyRef.current !== effectiveStrategy
   ) {
     controllerRef.current?.destroy();
-    controllerRef.current = new SharedStateController(key, initialState, effectiveStrategy, room);
+    controllerRef.current = new SharedStateController(
+      key,
+      initialState,
+      effectiveStrategy,
+      roomHandle
+    );
     prevKeyRef.current = key;
     prevStrategyRef.current = effectiveStrategy;
   }
@@ -87,8 +110,8 @@ export function useSharedState<
 
   // Keep controller room bindings in an effect to avoid render-phase side effects.
   useLayoutEffect(() => {
-    controller.syncRoom(room);
-  }, [controller, room.peerId, room.peers, room.broadcast, room.sendToPeer, room.onMessage, room.onPeerConnected]);
+    controller.syncRoom(roomHandle);
+  }, [controller, roomHandle]);
 
   // Destroy controller on unmount.
   useEffect(() => {
@@ -98,14 +121,15 @@ export function useSharedState<
     };
   }, []);
 
-  const state = useSyncExternalStore(controller.subscribe, controller.getState, controller.getState);
-
-  const setState = useCallback(
-    (next: SetStateAction<TState | null>): void => {
-      controllerRef.current?.setState(next);
-    },
-    [],
+  const state = useSyncExternalStore(
+    controller.subscribe,
+    controller.getState,
+    controller.getState
   );
+
+  const setState = useCallback((next: SetStateAction<TState | null>): void => {
+    controllerRef.current?.setState(next);
+  }, []);
 
   return [state, setState];
 }

--- a/packages/phop/src/index.ts
+++ b/packages/phop/src/index.ts
@@ -10,5 +10,7 @@ export {
   type MergeStrategy,
   type StrategyContext,
 } from './core/merge-strategies';
+export { SharedStateController, type RoomHandle } from './core/SharedStateController';
 export { useRoom, useSharedState } from './hooks';
+export { createSharedStore } from './store';
 export type { JSONSerializable, Message, MessageHandler } from './types';

--- a/packages/phop/src/index.ts
+++ b/packages/phop/src/index.ts
@@ -10,7 +10,7 @@ export {
   type MergeStrategy,
   type StrategyContext,
 } from './core/merge-strategies';
-export { SharedStateController, type RoomHandle } from './core/SharedStateController';
+export { type RoomHandle, SharedStateController } from './core/SharedStateController';
 export { useRoom, useSharedState } from './hooks';
 export { createSharedStore } from './store';
 export type { JSONSerializable, Message, MessageHandler } from './types';

--- a/packages/phop/src/store.ts
+++ b/packages/phop/src/store.ts
@@ -157,6 +157,10 @@ class StoreInstance<T, TMeta extends MergeMeta> {
     this.controller.syncRoom(room);
   }
 
+  start(): void {
+    this.controller.start();
+  }
+
   destroy(): void {
     this.controller.destroy();
     this.listeners.clear();
@@ -278,6 +282,7 @@ export function createSharedStore<T, TMeta extends MergeMeta = LamportMeta>(
 
     // Keep room bindings fresh outside render to preserve hook purity.
     useLayoutEffect(() => {
+      instance.start();
       instance.syncRoom(roomHandle);
     }, [instance, roomHandle]);
 

--- a/packages/phop/src/store.ts
+++ b/packages/phop/src/store.ts
@@ -1,21 +1,26 @@
-import { useCallback, useEffect, useLayoutEffect, useRef, useSyncExternalStore } from 'react';
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useSyncExternalStore,
+} from 'react';
 import {
   createLamportStrategy,
   type LamportMeta,
   type MergeMeta,
   type MergeStrategy,
 } from './core/merge-strategies';
-import { SharedStateController, type RoomHandle } from './core/SharedStateController';
-import type { JSONSerializable } from './types';
+import { type RoomHandle, SharedStateController } from './core/SharedStateController';
 import { useRoom } from './hooks/useRoom';
+import type { JSONSerializable } from './types';
 
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
 
-type SetState<T> = {
-  (partial: Partial<T> | ((prev: T) => Partial<T>)): void;
-};
+type SetState<T> = (partial: Partial<T> | ((prev: T) => Partial<T>)) => void;
 
 type GetState<T> = () => T;
 
@@ -98,7 +103,7 @@ class StoreInstance<T, TMeta extends MergeMeta> {
   constructor(
     descriptor: SharedStoreDescriptor<T, TMeta>,
     room: RoomHandle,
-    strategy: MergeStrategy<JSONSerializable, TMeta>,
+    strategy: MergeStrategy<JSONSerializable, TMeta>
   ) {
     this.partialize = descriptor.partialize ?? stripFunctions;
 
@@ -124,7 +129,7 @@ class StoreInstance<T, TMeta extends MergeMeta> {
       descriptor.key,
       initialSynced,
       strategy,
-      room,
+      room
     );
 
     // When the controller commits (remote update), merge the synced slice
@@ -199,13 +204,13 @@ export function createSharedStore<
 >(
   key: string,
   initializer: StoreInitializer<T>,
-  options: SharedStoreOptionsWithPartialize<T, TSynced, TMeta>,
+  options: SharedStoreOptionsWithPartialize<T, TSynced, TMeta>
 ): UseSharedStore<T>;
 
 export function createSharedStore<T, TMeta extends MergeMeta = LamportMeta>(
   key: string,
   initializer: StoreInitializer<T>,
-  options?: SharedStoreOptionsBase<TMeta>,
+  options?: SharedStoreOptionsBase<TMeta>
 ): UseSharedStore<T>;
 
 export function createSharedStore<T, TMeta extends MergeMeta = LamportMeta>(
@@ -214,7 +219,7 @@ export function createSharedStore<T, TMeta extends MergeMeta = LamportMeta>(
   options?: {
     partialize?: (state: T) => JSONSerializable;
     strategy?: MergeStrategy<JSONSerializable, TMeta>;
-  },
+  }
 ): UseSharedStore<T> {
   const descriptor: SharedStoreDescriptor<T, TMeta> = {
     key,
@@ -227,17 +232,30 @@ export function createSharedStore<T, TMeta extends MergeMeta = LamportMeta>(
   function useSharedStore<U>(selector: (state: T) => U, equalityFn?: EqualityFn<U>): U;
   function useSharedStore<U>(selector?: (state: T) => U, equalityFn?: EqualityFn<U>): T | U {
     const room = useRoom();
+    const roomHandle = useMemo(
+      () => ({
+        peerId: room.peerId,
+        peers: room.peers,
+        broadcast: room.broadcast,
+        sendToPeer: room.sendToPeer,
+        onMessage: room.onMessage,
+        onPeerConnected: room.onPeerConnected,
+      }),
+      [room]
+    );
     const localRegistryRef = useRef<StoreRegistry | null>(null);
 
     const peerIdRef = useRef(room.peerId);
     peerIdRef.current = room.peerId;
 
     const lamportRef = useRef<MergeStrategy<JSONSerializable, LamportMeta>>(
-      createLamportStrategy(() => peerIdRef.current),
+      createLamportStrategy(() => peerIdRef.current)
     );
 
-    const effectiveStrategy = (descriptor.strategy ??
-      lamportRef.current) as MergeStrategy<JSONSerializable, TMeta>;
+    const effectiveStrategy = (descriptor.strategy ?? lamportRef.current) as MergeStrategy<
+      JSONSerializable,
+      TMeta
+    >;
 
     if (localRegistryRef.current === null) {
       localRegistryRef.current = new Map();
@@ -250,7 +268,7 @@ export function createSharedStore<T, TMeta extends MergeMeta = LamportMeta>(
     let entry = registry.get(registryKey) as StoreRegistryEntry<T, TMeta> | undefined;
     if (!entry) {
       entry = {
-        instance: new StoreInstance(descriptor, room, effectiveStrategy),
+        instance: new StoreInstance(descriptor, roomHandle, effectiveStrategy),
         refCount: 0,
       };
       registry.set(registryKey, entry as unknown as StoreRegistryEntry<unknown, MergeMeta>);
@@ -260,8 +278,8 @@ export function createSharedStore<T, TMeta extends MergeMeta = LamportMeta>(
 
     // Keep room bindings fresh outside render to preserve hook purity.
     useLayoutEffect(() => {
-      instance.syncRoom(room);
-    }, [instance, room.peerId, room.peers, room.broadcast, room.sendToPeer, room.onMessage, room.onPeerConnected]);
+      instance.syncRoom(roomHandle);
+    }, [instance, roomHandle]);
 
     useEffect(() => {
       entry.refCount += 1;
@@ -270,7 +288,10 @@ export function createSharedStore<T, TMeta extends MergeMeta = LamportMeta>(
         entry.refCount -= 1;
         if (entry.refCount === 0) {
           entry.instance.destroy();
-          if (registry.get(registryKey) === (entry as unknown as StoreRegistryEntry<unknown, MergeMeta>)) {
+          if (
+            registry.get(registryKey) ===
+            (entry as unknown as StoreRegistryEntry<unknown, MergeMeta>)
+          ) {
             registry.delete(registryKey);
           }
         }
@@ -279,28 +300,35 @@ export function createSharedStore<T, TMeta extends MergeMeta = LamportMeta>(
 
     const subscribe = instance.subscribe;
     const getStateSnapshot = instance.getState;
-
-    if (!selector) {
-      return useSyncExternalStore(subscribe, getStateSnapshot, getStateSnapshot);
-    }
-
+    const selectorRef = useRef<typeof selector>(selector);
+    selectorRef.current = selector;
+    const equalityFnRef = useRef<typeof equalityFn>(equalityFn);
+    equalityFnRef.current = equalityFn;
     const hasSelectionRef = useRef(false);
     const selectedRef = useRef<U | undefined>(undefined);
-    const getSelectedSnapshot = useCallback((): U => {
-      const next = selector(instance.getState());
 
+    const getSnapshot = useCallback((): T | U => {
+      const state = getStateSnapshot();
+      const currentSelector = selectorRef.current;
+      if (!currentSelector) {
+        hasSelectionRef.current = false;
+        return state;
+      }
+
+      const next = currentSelector(state);
       if (hasSelectionRef.current) {
         const prev = selectedRef.current as U;
-        const equal = equalityFn ? equalityFn(prev, next) : prev === next;
+        const equal = equalityFnRef.current ? equalityFnRef.current(prev, next) : prev === next;
         if (equal) return prev;
       }
 
       hasSelectionRef.current = true;
       selectedRef.current = next;
       return next;
-    }, [instance, selector, equalityFn]);
+    }, [getStateSnapshot]);
 
-    return useSyncExternalStore(subscribe, getSelectedSnapshot, getSelectedSnapshot);
+    const snapshot = useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+    return snapshot as T | U;
   }
 
   return useSharedStore as UseSharedStore<T>;

--- a/packages/phop/src/store.ts
+++ b/packages/phop/src/store.ts
@@ -1,0 +1,307 @@
+import { useEffect, useRef, useSyncExternalStore } from 'react';
+import {
+  createLamportStrategy,
+  type LamportMeta,
+  type MergeMeta,
+  type MergeStrategy,
+} from './core/merge-strategies';
+import { SharedStateController, type RoomHandle } from './core/SharedStateController';
+import type { JSONSerializable } from './types';
+import { useRoom } from './hooks/useRoom';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+type SetState<T> = {
+  (partial: Partial<T> | ((prev: T) => Partial<T>)): void;
+};
+
+type GetState<T> = () => T;
+
+type StoreInitializer<T> = (set: SetState<T>, get: GetState<T>) => T;
+
+interface SharedStoreOptionsWithPartialize<
+  T,
+  TSynced extends JSONSerializable,
+  TMeta extends MergeMeta,
+> {
+  partialize: (state: T) => TSynced;
+  strategy?: MergeStrategy<TSynced, TMeta>;
+}
+
+interface SharedStoreOptionsBase<TMeta extends MergeMeta> {
+  strategy?: MergeStrategy<JSONSerializable, TMeta>;
+}
+
+/**
+ * Internal descriptor — always stores the optional partialize/strategy.
+ */
+interface SharedStoreDescriptor<T, TMeta extends MergeMeta> {
+  key: string;
+  initializer: StoreInitializer<T>;
+  partialize?: (state: T) => JSONSerializable;
+  strategy?: MergeStrategy<JSONSerializable, TMeta>;
+}
+
+type EqualityFn<T> = (a: T, b: T) => boolean;
+
+/**
+ * A hook returned by `createSharedStore`. Call inside a `<Room>` to bind the
+ * store to the current room context. Supports an optional selector for
+ * fine-grained re-renders.
+ */
+interface UseSharedStore<T> {
+  (): T;
+  <U>(selector: (state: T) => U, equalityFn?: EqualityFn<U>): U;
+}
+
+interface StoreRegistryEntry<T, TMeta extends MergeMeta> {
+  instance: StoreInstance<T, TMeta>;
+  refCount: number;
+}
+
+type StoreRegistry = Map<string, StoreRegistryEntry<unknown, MergeMeta>>;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Default partialize: strips function-valued properties so the remainder
+ * is safe to send over the wire as JSON. Used automatically when no
+ * explicit `partialize` option is provided.
+ */
+function stripFunctions(obj: unknown): JSONSerializable {
+  if (typeof obj !== 'object' || obj === null || Array.isArray(obj)) {
+    return obj as JSONSerializable;
+  }
+  const result: Record<string, JSONSerializable> = {};
+  for (const [k, v] of Object.entries(obj)) {
+    if (typeof v !== 'function') {
+      result[k] = v as JSONSerializable;
+    }
+  }
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// Internal: per-room store instance
+// ---------------------------------------------------------------------------
+
+class StoreInstance<T, TMeta extends MergeMeta> {
+  private state: T;
+  private readonly controller: SharedStateController<JSONSerializable, TMeta>;
+  private readonly listeners = new Set<() => void>();
+  private readonly partialize: (state: T) => JSONSerializable;
+
+  constructor(
+    descriptor: SharedStoreDescriptor<T, TMeta>,
+    room: RoomHandle,
+    strategy: MergeStrategy<JSONSerializable, TMeta>,
+  ) {
+    this.partialize = descriptor.partialize ?? stripFunctions;
+
+    const set: SetState<T> = (partial) => {
+      const currentState = this.state;
+      const nextPartial =
+        typeof partial === 'function'
+          ? (partial as (prev: T) => Partial<T>)(currentState)
+          : partial;
+      const nextState = { ...currentState, ...nextPartial } as T;
+      this.state = nextState;
+      this.notify();
+      this.controller.setState(this.partialize(nextState));
+    };
+
+    const get: GetState<T> = () => this.state;
+
+    this.state = descriptor.initializer(set, get);
+
+    const initialSynced = this.partialize(this.state);
+
+    this.controller = new SharedStateController<JSONSerializable, TMeta>(
+      descriptor.key,
+      initialSynced,
+      strategy,
+      room,
+    );
+
+    // When the controller commits (remote update), merge the synced slice
+    // back into the full store state, preserving non-synced fields (e.g.
+    // action functions) from the current state.
+    this.controller.subscribe(() => {
+      const synced = this.controller.getState();
+      if (synced !== null) {
+        this.state = Object.assign(Object.create(null), this.state, synced) as T;
+        this.notify();
+      }
+    });
+  }
+
+  getState = (): T => this.state;
+
+  subscribe = (listener: () => void): (() => void) => {
+    this.listeners.add(listener);
+    return () => {
+      this.listeners.delete(listener);
+    };
+  };
+
+  syncRoom(room: RoomHandle): void {
+    this.controller.syncRoom(room);
+  }
+
+  destroy(): void {
+    this.controller.destroy();
+    this.listeners.clear();
+  }
+
+  private notify(): void {
+    for (const listener of this.listeners) {
+      listener();
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Define a shared P2P store at module scope. Returns a React hook that, when
+ * called inside a `<Room>`, binds the store to the current room context.
+ *
+ * Function-valued properties (actions) are automatically stripped before
+ * syncing over the wire, and preserved locally on remote updates. Provide
+ * an explicit `partialize` option for fine-grained control over the synced
+ * slice.
+ *
+ * API mirrors Zustand's `create`:
+ *
+ * ```ts
+ * const useCounterStore = createSharedStore('counter', (set) => ({
+ *   count: 0,
+ *   increment: () => set((s) => ({ count: s.count + 1 })),
+ * }));
+ *
+ * function Counter() {
+ *   const count = useCounterStore((s) => s.count);
+ *   const increment = useCounterStore((s) => s.increment);
+ *   return <button onClick={increment}>Count: {count}</button>;
+ * }
+ * ```
+ */
+export function createSharedStore<
+  T,
+  TSynced extends JSONSerializable,
+  TMeta extends MergeMeta = LamportMeta,
+>(
+  key: string,
+  initializer: StoreInitializer<T>,
+  options: SharedStoreOptionsWithPartialize<T, TSynced, TMeta>,
+): UseSharedStore<T>;
+
+export function createSharedStore<T, TMeta extends MergeMeta = LamportMeta>(
+  key: string,
+  initializer: StoreInitializer<T>,
+  options?: SharedStoreOptionsBase<TMeta>,
+): UseSharedStore<T>;
+
+export function createSharedStore<T, TMeta extends MergeMeta = LamportMeta>(
+  key: string,
+  initializer: StoreInitializer<T>,
+  options?: {
+    partialize?: (state: T) => JSONSerializable;
+    strategy?: MergeStrategy<JSONSerializable, TMeta>;
+  },
+): UseSharedStore<T> {
+  const descriptor: SharedStoreDescriptor<T, TMeta> = {
+    key,
+    initializer,
+    partialize: options?.partialize,
+    strategy: options?.strategy,
+  };
+
+  function useSharedStore(): T;
+  function useSharedStore<U>(selector: (state: T) => U, equalityFn?: EqualityFn<U>): U;
+  function useSharedStore<U>(selector?: (state: T) => U, equalityFn?: EqualityFn<U>): T | U {
+    const room = useRoom();
+    const localRegistryRef = useRef<StoreRegistry | null>(null);
+
+    const peerIdRef = useRef(room.peerId);
+    peerIdRef.current = room.peerId;
+
+    const lamportRef = useRef<MergeStrategy<JSONSerializable, LamportMeta>>(
+      createLamportStrategy(() => peerIdRef.current),
+    );
+
+    const effectiveStrategy = (descriptor.strategy ??
+      lamportRef.current) as MergeStrategy<JSONSerializable, TMeta>;
+
+    if (localRegistryRef.current === null) {
+      localRegistryRef.current = new Map();
+    }
+
+    const registry = (room.__internalStoreRegistry ??
+      localRegistryRef.current) as unknown as StoreRegistry;
+    const registryKey = `shared-store:${descriptor.key}`;
+
+    let entry = registry.get(registryKey) as StoreRegistryEntry<T, TMeta> | undefined;
+    if (!entry) {
+      entry = {
+        instance: new StoreInstance(descriptor, room, effectiveStrategy),
+        refCount: 0,
+      };
+      registry.set(registryKey, entry as unknown as StoreRegistryEntry<unknown, MergeMeta>);
+    }
+
+    const instance = entry.instance;
+
+    instance.syncRoom(room);
+
+    useEffect(() => {
+      entry.refCount += 1;
+
+      return () => {
+        entry.refCount -= 1;
+        if (entry.refCount === 0) {
+          entry.instance.destroy();
+          if (registry.get(registryKey) === (entry as unknown as StoreRegistryEntry<unknown, MergeMeta>)) {
+            registry.delete(registryKey);
+          }
+        }
+      };
+    }, [entry, registry, registryKey]);
+
+    const getSnapshot = instance.getState;
+    const subscribe = instance.subscribe;
+
+    const state = useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+
+    const selectorRef = useRef(selector);
+    selectorRef.current = selector;
+    const equalityFnRef = useRef(equalityFn);
+    equalityFnRef.current = equalityFn;
+    const selectedRef = useRef<U | undefined>(undefined);
+
+    if (!selector) return state;
+
+    const selected = selector(state);
+
+    // Bail out of re-render if the selected slice is equal.
+    if (
+      selectedRef.current !== undefined &&
+      equalityFnRef.current
+        ? equalityFnRef.current(selectedRef.current as U, selected)
+        : selectedRef.current === selected
+    ) {
+      return selectedRef.current as U;
+    }
+
+    selectedRef.current = selected;
+    return selected;
+  }
+
+  return useSharedStore as UseSharedStore<T>;
+}

--- a/packages/phop/src/store.ts
+++ b/packages/phop/src/store.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useSyncExternalStore } from 'react';
+import { useCallback, useEffect, useLayoutEffect, useRef, useSyncExternalStore } from 'react';
 import {
   createLamportStrategy,
   type LamportMeta,
@@ -133,7 +133,7 @@ class StoreInstance<T, TMeta extends MergeMeta> {
     this.controller.subscribe(() => {
       const synced = this.controller.getState();
       if (synced !== null) {
-        this.state = Object.assign(Object.create(null), this.state, synced) as T;
+        this.state = Object.assign({}, this.state, synced) as T;
         this.notify();
       }
     });
@@ -258,7 +258,10 @@ export function createSharedStore<T, TMeta extends MergeMeta = LamportMeta>(
 
     const instance = entry.instance;
 
-    instance.syncRoom(room);
+    // Keep room bindings fresh outside render to preserve hook purity.
+    useLayoutEffect(() => {
+      instance.syncRoom(room);
+    }, [instance, room.peerId, room.peers, room.broadcast, room.sendToPeer, room.onMessage, room.onPeerConnected]);
 
     useEffect(() => {
       entry.refCount += 1;
@@ -274,33 +277,30 @@ export function createSharedStore<T, TMeta extends MergeMeta = LamportMeta>(
       };
     }, [entry, registry, registryKey]);
 
-    const getSnapshot = instance.getState;
     const subscribe = instance.subscribe;
+    const getStateSnapshot = instance.getState;
 
-    const state = useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
-
-    const selectorRef = useRef(selector);
-    selectorRef.current = selector;
-    const equalityFnRef = useRef(equalityFn);
-    equalityFnRef.current = equalityFn;
-    const selectedRef = useRef<U | undefined>(undefined);
-
-    if (!selector) return state;
-
-    const selected = selector(state);
-
-    // Bail out of re-render if the selected slice is equal.
-    if (
-      selectedRef.current !== undefined &&
-      equalityFnRef.current
-        ? equalityFnRef.current(selectedRef.current as U, selected)
-        : selectedRef.current === selected
-    ) {
-      return selectedRef.current as U;
+    if (!selector) {
+      return useSyncExternalStore(subscribe, getStateSnapshot, getStateSnapshot);
     }
 
-    selectedRef.current = selected;
-    return selected;
+    const hasSelectionRef = useRef(false);
+    const selectedRef = useRef<U | undefined>(undefined);
+    const getSelectedSnapshot = useCallback((): U => {
+      const next = selector(instance.getState());
+
+      if (hasSelectionRef.current) {
+        const prev = selectedRef.current as U;
+        const equal = equalityFn ? equalityFn(prev, next) : prev === next;
+        if (equal) return prev;
+      }
+
+      hasSelectionRef.current = true;
+      selectedRef.current = next;
+      return next;
+    }, [instance, selector, equalityFn]);
+
+    return useSyncExternalStore(subscribe, getSelectedSnapshot, getSelectedSnapshot);
   }
 
   return useSharedStore as UseSharedStore<T>;

--- a/packages/phop/vitest.config.ts
+++ b/packages/phop/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'jsdom',
+  },
+});


### PR DESCRIPTION
## Motivation

Wanted to improve developer experience by introducing store API.

## Overview

- Added `createSharedStore` to `@peterddod/phop` with:
  - room-scoped shared store instances
  - synced state via extracted `SharedStateController`
  - support for selector-based subscriptions
  - exports/docs/tests for the new API

- Refactored shared-state internals:
  - extracted shared protocol guards into `shared-state-protocol`
  - moved room sync from render into layout effects to keep hooks render-pure
  - fixed StrictMode remount safety by clearing controller refs on cleanup
  - added functional updater support for `useSharedState`

- Improved selector behavior:
  - implemented selector-aware snapshot flow so unrelated slice updates do not force re-renders
  - added render-count test coverage for selector isolation

- Updated example app:
  - added shared label demo using `createSharedStore`
  - kept counter demo using `useSharedState`
  - switched iframe peers to a per-page room id to avoid cross-session collisions

- Added integration regression coverage:
  - label synchronization scenarios (local echo, multi-char typing, peer handoff)
  - counter synchronization scenario while shared store is mounted
  - harness helpers/probe APIs to reproduce and assert these behaviors precisely

- CI updates:
  - added dedicated `phop-unit-test` job
  - runs in parallel with integration tests
  - required by release pipeline before semantic-release

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced createSharedStore for fine-grained shared stores; example app now supports dynamic room IDs and a shared label/color UI demonstrating cross-peer sync

* **Documentation**
  * Updated README with createSharedStore examples and a comparison versus useSharedState

* **Tests**
  * Added extensive unit and integration tests covering shared state, stores, and label probing

* **Chores**
  * CI updated to run a dedicated unit-test job for the package suite
<!-- end of auto-generated comment: release notes by coderabbit.ai -->